### PR TITLE
Coerce query cutoff values

### DIFF
--- a/rest_controller.r
+++ b/rest_controller.r
@@ -129,6 +129,11 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
 #* @param value A decimal, 0-1, representing a cutoff/threshold; returns blockgroups whose percentile rank for the attribute is larger (e.g. pctunemployed > .9)
 #* @post /query
 function(attribute = "pctunemployed", value=.9, res) {
+    value <- suppressWarnings(as.numeric(value))
+    if (length(value) != 1 || is.na(value) || value < 0 || value > 1) {
+      res$status <- 400
+      return(handle_error("value must be a numeric cutoff from 0 to 1."))
+    }
     these <- pctile_x_is_hit_by_score(attribute, cutoff = value)
     results <- blockgroupstats[these,]
     return (results)

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -129,14 +129,14 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
 #* @param value A decimal, 0-1, representing a cutoff/threshold; returns blockgroups whose percentile rank for the attribute is larger (e.g. pctunemployed > .9)
 #* @post /query
 function(attribute = "pctunemployed", value=.9, res) {
-    value <- suppressWarnings(as.numeric(value))
-    if (length(value) != 1 || is.na(value) || value < 0 || value > 1) {
-      res$status <- 400
-      return(handle_error("value must be a numeric cutoff from 0 to 1."))
-    }
-    these <- pctile_x_is_hit_by_score(attribute, cutoff = value)
-    results <- blockgroupstats[these,]
-    return (results)
+  value <- suppressWarnings(as.numeric(value))
+  if (length(value) != 1 || is.na(value) || value < 0 || value > 1) {
+    res$status <- 400
+    return(handle_error("value must be a numeric cutoff from 0 to 1."))
+  }
+  these <- pctile_x_is_hit_by_score(attribute, cutoff = value)
+  results <- blockgroupstats[these,]
+  return (results)
 }
 
 #* Generate an EJAM report


### PR DESCRIPTION
Coerce query value inputs to numeric and reject invalid cutoffs so /query handles numeric-like strings consistently.