### PR TITLE
Multisite GET /report, bounded token handoff, and CORS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,8 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
     echo 'CHROMOTE_CHROME=/usr/local/bin/google-chrome' >> /etc/R/Renviron.site
 
 # Clone EJAM
-# Bumped from v2.32.8.1 -> v3.2022.0: the multisite-via-API path (GET /report
-# with sitenumber=0 rendering results_overall) is mature in the v3.x line.
-RUN git clone --branch v3.2022.0 --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM-3.2022.0 && \
-    cd /EJAM-3.2022.0 && \
+RUN git clone --branch v2.32.8.1 --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM-2.32.8.1 && \
+    cd /EJAM-2.32.8.1 && \
     git lfs pull
 
 # Install Dependencies & EJAM
@@ -58,19 +56,19 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
     options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest')); \
     \
     # Pre-install key dependencies first \
-    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr', 'openssl')); \
+    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr')); \
     \
     # Install a fixed fork of AOI \
     remotes::install_github('ericnost/AOI', upgrade='never'); \
     \
     # Install EJAM using upgrade='never' so it doesn't break the stable environment \
-    remotes::install_local('/EJAM-3.2022.0', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
+    remotes::install_local('/EJAM-2.32.8.1', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
     \
     # Verify installation \
     if (!('EJAM' %in% installed.packages()[, 'Package'])) stop('EJAM FAILED TO INSTALL!'); \
     " && \
     # Clean up the cloned source directory \
-    rm -rf /EJAM-3.2022.0
+    rm -rf /EJAM-2.32.8.1
 
 # Reset frontend
 ENV DEBIAN_FRONTEND=dialog

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,10 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
     echo 'CHROMOTE_CHROME=/usr/local/bin/google-chrome' >> /etc/R/Renviron.site
 
 # Clone EJAM
-RUN git clone --branch v2.32.8.1 --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM-2.32.8.1 && \
-    cd /EJAM-2.32.8.1 && \
+# Bumped from v2.32.8.1 -> v3.2022.0: the multisite-via-API path (GET /report
+# with sitenumber=0 rendering results_overall) is mature in the v3.x line.
+RUN git clone --branch v3.2022.0 --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM-3.2022.0 && \
+    cd /EJAM-3.2022.0 && \
     git lfs pull
 
 # Install Dependencies & EJAM
@@ -62,13 +64,13 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
     remotes::install_github('ericnost/AOI', upgrade='never'); \
     \
     # Install EJAM using upgrade='never' so it doesn't break the stable environment \
-    remotes::install_local('/EJAM-2.32.8.1', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
+    remotes::install_local('/EJAM-3.2022.0', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
     \
     # Verify installation \
     if (!('EJAM' %in% installed.packages()[, 'Package'])) stop('EJAM FAILED TO INSTALL!'); \
     " && \
     # Clean up the cloned source directory \
-    rm -rf /EJAM-2.32.8.1
+    rm -rf /EJAM-3.2022.0
 
 # Reset frontend
 ENV DEBIAN_FRONTEND=dialog

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
     options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest')); \
     \
     # Pre-install key dependencies first \
-    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr')); \
+    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr', 'openssl')); \
     \
     # Install a fixed fork of AOI \
     remotes::install_github('ericnost/AOI', upgrade='never'); \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ A multisite report over two counties: https://ejamapi-84652557241.us-central1.ru
 
 A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652557241.us-central1.run.app/report?shape=%7B"type"%3A"FeatureCollection"%2C"features"%3A%5B%7B"type"%3A"Feature"%2C"properties"%3A%7B%7D%2C"geometry"%3A%7B"coordinates"%3A%5B%5B%5B-112.01991856401462%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.51124624304089%5D%5D%5D%2C"type"%3A"Polygon"%7D%7D%5D%7D&buffer=0
 
+### Multisite report via POST
+
+`report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large/mixed site sets) that would not fit in a GET URL. It uses the same report engine and accepts the same body as `data` (`sites`, `shape`, `fips`, `buffer`, `scale`), plus:
+- `sitenumber` - default `0` = aggregate **multisite report**; a positive integer reports on that one site.
+- `fileextension` - `html` (default) or `pdf`.
+
+Each `fips` code is a separate site. `shape` is a GeoJSON FeatureCollection string (one or more polygons). Returns the rendered report (HTML or PDF), same as GET `/report`.
+
+```
+# A multisite report over several drawn polygons
+import json, requests
+payload = {"shape": json.dumps(feature_collection), "buffer": 0, "sitenumber": 0, "fileextension": "html"}
+html = requests.post("https://ejamapi-84652557241.us-central1.run.app/report", json=payload).text
+```
+
 ## Data
 `data` accepts POST requests with the following parameters:
 - `sites` - a list of lat/lon pairs e.g. `[{"lat":33, "lon":-112}, {"lat":34, "lon":-114}]`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The API exposes report and data endpoints, plus a token-based handoff for launch
 - `lon` - the longitude
 - `fips` - A FIPS code for a specific US Census geography, like fips=10 for one state, or comma-separated list like fips=10001,10003,10005 for 3 counties
 - `shape` - a GeoJSON text-encoded object describing an area of interest, such as a polygon of neighborhood boundaries
-- `buffer` - radius, in miles, around a point or out from the edge of a polygon to extend the search. EJAM default = 3. *Note: adding buffers around fips units may not be implemented yet.
+- `buffer` (or `radius`, a synonym) - radius, in miles, around a point or out from the edge of a polygon to extend the search. EJAM default = 3. *Note: adding buffers around fips units may not be implemented yet.
 - `sitenumber` - which site to report on when more than one is supplied. Default = 1 (a single-site report on the first site). Use `sitenumber=0` (or `sitenumber=overall`) to get an aggregate **multisite report** that summarizes all of the supplied sites together. Each comma-separated `fips` code is treated as a separate site (no expansion), so `fips=10001,10003&sitenumber=0` reports on those two counties together.
 - `fileextension` - `pdf` (default) or `html`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652
 
 ### Multisite report via POST
 
-`report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large/mixed site sets) that would not fit in a GET URL. It uses the same report engine and accepts `sites`, `shape`, `fips`, and `buffer` (like `data`, but `scale` is not used for reports -- each FIPS is reported as its own site), plus:
+`report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large site sets) that would not fit in a GET URL. It uses the same report engine and accepts `sites`, `shape`, `fips`, and `buffer` (like `data`, but `scale` is not used for reports -- each FIPS is reported as its own site). Provide exactly one of `sites`, `shape`, or `fips` per request, plus:
 - `sitenumber` - default `0` = aggregate **multisite report**; a positive integer reports on that one site.
 - `fileextension` - `html` (default) or `pdf`.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Recreating that API would require extensive reverse engineering of the ArcGIS ma
 # Model
 The API exposes report and data endpoints, plus a token-based handoff for launching the EJAM app pre-loaded.
 
+## Base URLs
+The canonical base URL is the Cloud Run service:
+`https://ejamapi-84652557241.us-central1.run.app`
+
+A friendlier branded base is also available now and proxies the **same** API through Cloudflare (with permissive CORS for browser apps):
+`https://api.ejanalysis.com` (and the equivalent alias `https://ejamapi.ejanalysis.com`)
+
+All of the example URLs below work with either base — just swap the host. For example, `https://api.ejanalysis.com/report?buffer=1&fips=10001` is equivalent to the Cloud Run URL. (The EJAM R package reads its API base from one place, the `ejam_api_url` field in its `DESCRIPTION`, so it can point at either base; see `?url_package` and `?url_ejamapi` in EJAM.)
+
 ## Reports
 `report` accepts GET requests with the following parameters:
 - `lat` - the latitude of a given point, or comma-separated list like lat=33,32.5

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Two endpoints let an external app (e.g. EJScreen) hand a set of selected places 
 
 The caller opens the EJAM app at `https://ejam.publicenvirodata.org/?handoff=<token>`; the app fetches `GET /handoff/<token>` on startup and pre-loads those places.
 
-> The current store is in-process with a 1-hour TTL. On Cloud Run with more than one instance, a token created on one instance will not resolve on another — use a shared store (GCS/Firestore/Redis) or run with `min-instances=1` and a single max instance.
+> The current store is in-process with a 1-hour TTL and bounded capacity. By default, `POST /handoff` accepts payloads up to 1 MiB (`HANDOFF_MAX_PAYLOAD_BYTES=1048576`) and up to 64 active tokens (`HANDOFF_MAX_TOKENS=64`) before returning an error. On Cloud Run with more than one instance, a token created on one instance will not resolve on another — use a shared store (GCS/Firestore/Redis) or run with `min-instances=1` and a single max instance.
 
 ## CORS
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Two endpoints let an external app (e.g. EJScreen) hand a set of selected places 
 
 The caller opens the EJAM app at `https://ejam.publicenvirodata.org/?handoff=<token>`; the app fetches `GET /handoff/<token>` on startup and pre-loads those places.
 
-> The current store is in-process with a 1-hour TTL and bounded capacity. By default, `POST /handoff` accepts payloads up to 1 MiB (`HANDOFF_MAX_PAYLOAD_BYTES=1048576`) and up to 64 active tokens (`HANDOFF_MAX_TOKENS=64`) before returning an error. On Cloud Run with more than one instance, a token created on one instance will not resolve on another — use a shared store (GCS/Firestore/Redis) or run with `min-instances=1` and a single max instance.
+> The current store is in-process with a 1-hour TTL and bounded capacity. By default, `POST /handoff` accepts payloads up to 1 MiB (`HANDOFF_MAX_PAYLOAD_BYTES=1048576`) and up to 64 active tokens (`HANDOFF_MAX_TOKENS=64`) before returning an error. Token-collision retries are bounded (`HANDOFF_TOKEN_COLLISION_RETRIES=8`). On Cloud Run with more than one instance, a token created on one instance will not resolve on another — use a shared store (GCS/Firestore/Redis) or run with `min-instances=1` and a single max instance.
 
 ## CORS
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652
 
 ### Multisite report via POST
 
-`report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large/mixed site sets) that would not fit in a GET URL. It uses the same report engine and accepts the same body as `data` (`sites`, `shape`, `fips`, `buffer`, `scale`), plus:
+`report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large/mixed site sets) that would not fit in a GET URL. It uses the same report engine and accepts `sites`, `shape`, `fips`, and `buffer` (like `data`, but `scale` is not used for reports -- each FIPS is reported as its own site), plus:
 - `sitenumber` - default `0` = aggregate **multisite report**; a positive integer reports on that one site.
 - `fileextension` - `html` (default) or `pdf`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In February 2025, USEPA removed its EJSCREEN website from public access, includi
 Recreating that API would require extensive reverse engineering of the ArcGIS map server(s) that hosted the API functionality. Instead, our approach is to draw on [EJAM](https://github.com/ejanalysis/EJAM), the non-EPA version of an open-source R package that provides EJSCREEN's "multisite" reporting feature. EJAM was designed to produce EJSCREEN-style community reports, including single-site reports and multisite reports (summaries over multiple locations). The EJAM package itself does not currently provide an API; this repo contains files necessary to create a Docker image of EJAM and its dependencies as well as an API model.
 
 # Model
-There are currently two endpoints for the API.
+The API exposes report and data endpoints, plus a token-based handoff for launching the EJAM app pre-loaded.
 
 ## Reports
 `report` accepts GET requests with the following parameters:
@@ -15,14 +15,19 @@ There are currently two endpoints for the API.
 - `fips` - A FIPS code for a specific US Census geography, like fips=10 for one state, or comma-separated list like fips=10001,10003,10005 for 3 counties
 - `shape` - a GeoJSON text-encoded object describing an area of interest, such as a polygon of neighborhood boundaries
 - `buffer` - radius, in miles, around a point or out from the edge of a polygon to extend the search. EJAM default = 3. *Note: adding buffers around fips units may not be implemented yet.
+- `sitenumber` - which site to report on when more than one is supplied. Default = 1 (a single-site report on the first site). Use `sitenumber=0` (or `sitenumber=overall`) to get an aggregate **multisite report** that summarizes all of the supplied sites together. Each comma-separated `fips` code is treated as a separate site (no expansion), so `fips=10001,10003&sitenumber=0` reports on those two counties together.
+- `fileextension` - `pdf` (default) or `html`.
 
-`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0.
-An HTML format of a report is returned.
+`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. With `fileextension=html`, an HTML report is returned; otherwise a PDF.
 
 ### Examples
 A County: https://ejamapi-84652557241.us-central1.run.app/report?buffer=1&fips=10001
 
 A point in the Phoenix area with a 4 mile buffer (radius): https://ejamapi-84652557241.us-central1.run.app/report?lat=33&lon=-112&buffer=4
+
+A multisite report over two points: https://ejamapi-84652557241.us-central1.run.app/report?lat=33,34&lon=-112,-114&buffer=3&sitenumber=0&fileextension=html
+
+A multisite report over two counties: https://ejamapi-84652557241.us-central1.run.app/report?fips=10001,10003&sitenumber=0&fileextension=html
 
 A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652557241.us-central1.run.app/report?shape=%7B"type"%3A"FeatureCollection"%2C"features"%3A%5B%7B"type"%3A"Feature"%2C"properties"%3A%7B%7D%2C"geometry"%3A%7B"coordinates"%3A%5B%5B%5B-112.01991856401462%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.51124624304089%5D%5D%5D%2C"type"%3A"Polygon"%7D%7D%5D%7D&buffer=0
 
@@ -62,6 +67,21 @@ response = requests.post(url, json=data)
 df = pandas.DataFrame.from_dict(response.json())
 df
 ```
+
+## Handoff (launch the EJAM app pre-loaded)
+
+Two endpoints let an external app (e.g. EJScreen) hand a set of selected places to the full EJAM app without hitting URL-length limits (important for polygons):
+
+- `POST /handoff` — body may contain `sites` (array of `{lat,lon}`), `fips` (array of codes), `shape` (a GeoJSON `FeatureCollection`), and `radius`. Returns `{"token": "...", "expires": <epoch seconds>}`.
+- `GET /handoff/<token>` — returns the stored payload as JSON.
+
+The caller opens the EJAM app at `https://ejam.publicenvirodata.org/?handoff=<token>`; the app fetches `GET /handoff/<token>` on startup and pre-loads those places.
+
+> The current store is in-process with a 1-hour TTL. On Cloud Run with more than one instance, a token created on one instance will not resolve on another — use a shared store (GCS/Firestore/Redis) or run with `min-instances=1` and a single max instance.
+
+## CORS
+
+All routes send `Access-Control-Allow-Origin: *` and answer `OPTIONS` preflight requests, so browser apps can `fetch()`/POST cross-origin (needed for `/handoff` and any future POST report endpoint). The single-site report flow uses a top-level `window.open()` GET and does not depend on CORS.
 
 # Set-up
 1. Work locally with EJAM by installing R/RStudio. Follow the [installation instructions](https://ejanalysis.github.io/EJAM/articles/installing.html) in the [EJAM documentation](https://ejanalysis.org/ejamdocs).

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -331,12 +331,13 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 # or run the service with min-instances=1 and a single max instance.
 .handoff_store    <- new.env(parent = emptyenv())
 .handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
-.handoff_env_num_or <- function(name, default_value) {
+.handoff_env_numeric_or_default <- function(name, default_value) {
   val <- suppressWarnings(as.numeric(Sys.getenv(name, as.character(default_value))))
   if (!is.finite(val) || val <= 0) default_value else val
 }
-.handoff_max_tokens <- .handoff_env_num_or("HANDOFF_MAX_TOKENS", 64)
-.handoff_max_payload_bytes <- .handoff_env_num_or("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
+.handoff_max_tokens <- .handoff_env_numeric_or_default("HANDOFF_MAX_TOKENS", 64)
+.handoff_max_payload_bytes <- .handoff_env_numeric_or_default("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
+.handoff_token_collision_retries <- 8L
 
 .handoff_new_token <- function() {
   # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
@@ -384,7 +385,7 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens).", as.integer(.handoff_max_tokens))))
   }
   token <- NULL
-  for (i in seq_len(8)) {
+  for (i in seq_len(.handoff_token_collision_retries)) {
     candidate <- .handoff_new_token()
     if (is.null(.handoff_store[[candidate]])) {
       token <- candidate

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -331,6 +331,12 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 # or run the service with min-instances=1 and a single max instance.
 .handoff_store    <- new.env(parent = emptyenv())
 .handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
+.handoff_env_num_or <- function(name, default_value) {
+  val <- suppressWarnings(as.numeric(Sys.getenv(name, as.character(default_value))))
+  if (!is.finite(val) || val <= 0) default_value else val
+}
+.handoff_max_tokens <- .handoff_env_num_or("HANDOFF_MAX_TOKENS", 64)
+.handoff_max_payload_bytes <- .handoff_env_num_or("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
 
 .handoff_new_token <- function() {
   # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
@@ -364,10 +370,20 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   if (is.null(method)) {
     method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
   }
+  payload <- list(method = method, sites = sites, fips = fips, shape = shape, radius = radius)
+  payload_bytes <- length(serialize(payload, connection = NULL))
+  if (is.finite(.handoff_max_payload_bytes) && payload_bytes > .handoff_max_payload_bytes) {
+    res$status <- 413
+    return(handle_error(sprintf("Handoff payload too large (max %s bytes).", as.integer(.handoff_max_payload_bytes))))
+  }
+  if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
+    res$status <- 429
+    return(handle_error(sprintf("Handoff token capacity reached (max %s active tokens).", as.integer(.handoff_max_tokens))))
+  }
   token   <- .handoff_new_token()
   expires <- floor(as.numeric(Sys.time())) + .handoff_ttl_secs  # integer epoch seconds
   .handoff_store[[token]] <- list(
-    payload = list(method = method, sites = sites, fips = fips, shape = shape, radius = radius),
+    payload = payload,
     expires = expires
   )
   # The token is a bearer credential -- don't let it sit in shared/proxy caches.

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -333,7 +333,10 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 .handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
 .handoff_env_numeric_or_default <- function(name, default_value) {
   val <- suppressWarnings(as.numeric(Sys.getenv(name, as.character(default_value))))
-  if (!is.finite(val) || val <= 0) default_value else val
+  if (!is.finite(val) || val <= 0) {
+    return(default_value)
+  }
+  val
 }
 .handoff_max_tokens <- .handoff_env_numeric_or_default("HANDOFF_MAX_TOKENS", 64)
 .handoff_max_payload_bytes <- .handoff_env_numeric_or_default("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
@@ -373,6 +376,10 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   if (is.null(method)) {
     method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
   }
+  if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
+    res$status <- 429
+    return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens). Retry after a short delay; tokens expire after 1 hour.", as.integer(.handoff_max_tokens))))
+  }
   payload <- list(method = method, sites = sites, fips = fips, shape = shape, radius = radius)
   payload_raw <- serialize(payload, connection = NULL)
   payload_bytes <- length(payload_raw)
@@ -380,12 +387,8 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     res$status <- 413
     return(handle_error(sprintf("Handoff payload size %d bytes exceeds limit of %d bytes.", payload_bytes, as.integer(.handoff_max_payload_bytes))))
   }
-  if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
-    res$status <- 429
-    return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens). Retry after a short delay; tokens expire after 1 hour.", as.integer(.handoff_max_tokens))))
-  }
   token <- NULL
-  for (i in seq_len(.handoff_token_collision_retries)) {
+  for (attempt in seq_len(.handoff_token_collision_retries)) {
     candidate <- .handoff_new_token()
     if (is.null(.handoff_store[[candidate]])) {
       token <- candidate

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -99,10 +99,12 @@ function(req, res) {
 }
 
 #* Return EJAM analysis data as JSON based on geography
+#* @tag Data
 #* @param sites A data frame of site coordinates (lat/lon)
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
 #* @param buffer The buffer radius in miles
+#* @param radius Synonym for buffer.
 #* @param geometries A boolean to indicate whether to include geometries in the output
 #* @param scale The Census geography at which to return results (blockgroup or county)
 #* @post /data
@@ -146,6 +148,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, geo
 }
 
 #* Return EJAM analysis data as JSON based on attribute query
+#* @tag Data
 #* @param attribute An EJSCREEN attribute, in EJAM syntax (e.g. pctunemployed)
 #* @param value A decimal, 0-1, representing a cutoff/threshold; returns blockgroups whose percentile rank for the attribute is larger (e.g. pctunemployed > .9)
 #* @post /query
@@ -197,11 +200,13 @@ report_response <- function(result, method, to_map, sitenum, ext, res) {
 }
 
 #* Generate an EJAM report
+#* @tag Reports
 #* @param lat Latitude of the site
 #* @param lon Longitude of the site
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
 #* @param buffer The buffer radius in miles
+#* @param radius Synonym for buffer.
 #* @param sitenumber Which site to report on. Defaults to 1 (single-site). Use 0 (or "overall") for an aggregate MULTISITE report across all sites.
 #* @param fileextension Whether to return a PDF or HTML file. Defaults to PDF.
 #* @serializer contentType list(type = "application/octet-stream")
@@ -275,10 +280,12 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
 
 #* Generate an EJAM report from a POST body (supports many/large polygons and mixed/large site sets).
 #* Same report engine as GET /report, but inputs travel in the request body so there is no URL-length limit.
+#* @tag Reports
 #* @param sites An array of {lat, lon} site objects
 #* @param shape A GeoJSON FeatureCollection string (one or more polygons)
 #* @param fips An array of FIPS codes (each one a separate site)
 #* @param buffer The buffer radius in miles (out from a polygon edge, or around a point)
+#* @param radius Synonym for buffer.
 #* @param sitenumber Which site to report on. Defaults to 0 = aggregate MULTISITE report across all sites.
 #* @param fileextension "html" (default) or "pdf"
 #* @serializer contentType list(type = "application/octet-stream")
@@ -360,11 +367,13 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 
 #* Store a set of selected sites for handoff to the EJAM app; returns a token.
+#* @tag Handoff
 #* @param method One of "latlon", "FIPS", or "SHP" (optional; inferred if omitted)
 #* @param sites Array of {lat, lon} site objects
 #* @param fips Array of FIPS codes (each one a separate site)
 #* @param shape A GeoJSON FeatureCollection of polygons
 #* @param radius Buffer radius in miles
+#* @param buffer Synonym for radius.
 #* @post /handoff
 function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, buffer = NULL, res) {
   if (is.null(radius)) {radius <- buffer}  # buffer is a synonym (alias) for radius
@@ -410,6 +419,7 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
 }
 
 #* Retrieve a previously stored handoff payload by token.
+#* @tag Handoff
 #* @param token The handoff token returned by POST /handoff
 #* @get /handoff/<token>
 function(token, res) {

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -337,7 +337,6 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 .handoff_max_tokens <- .handoff_env_num_or("HANDOFF_MAX_TOKENS", 64)
 .handoff_max_payload_bytes <- .handoff_env_num_or("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
-.handoff_active_tokens <- 0L
 
 .handoff_new_token <- function() {
   # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
@@ -349,15 +348,10 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 .handoff_purge_expired <- function() {
   now <- as.numeric(Sys.time())
-  removed <- 0L
   for (k in ls(.handoff_store)) {
     if (.handoff_store[[k]]$expires < now) {
       rm(list = k, envir = .handoff_store)
-      removed <- removed + 1L
     }
-  }
-  if (removed > 0L) {
-    .handoff_active_tokens <<- max(0L, .handoff_active_tokens - removed)
   }
 }
 
@@ -385,18 +379,27 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     res$status <- 413
     return(handle_error(sprintf("Handoff payload too large (max %d bytes).", as.integer(.handoff_max_payload_bytes))))
   }
-  if (is.finite(.handoff_max_tokens) && .handoff_active_tokens >= .handoff_max_tokens) {
+  if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
     res$status <- 429
     return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens).", as.integer(.handoff_max_tokens))))
   }
-  token   <- .handoff_new_token()
-  while (!is.null(.handoff_store[[token]])) token <- .handoff_new_token()
+  token <- NULL
+  for (i in seq_len(8)) {
+    candidate <- .handoff_new_token()
+    if (is.null(.handoff_store[[candidate]])) {
+      token <- candidate
+      break
+    }
+  }
+  if (is.null(token)) {
+    res$status <- 503
+    return(handle_error("Unable to mint a unique handoff token; retry request."))
+  }
   expires <- floor(as.numeric(Sys.time())) + .handoff_ttl_secs  # integer epoch seconds
   .handoff_store[[token]] <- list(
     payload_raw = payload_raw,
     expires = expires
   )
-  .handoff_active_tokens <<- .handoff_active_tokens + 1L
   # The token is a bearer credential -- don't let it sit in shared/proxy caches.
   res$setHeader("Cache-Control", "no-store")
   list(token = token, expires = expires)
@@ -413,7 +416,7 @@ function(token, res) {
     return(handle_error("Unknown or expired handoff token."))
   }
   res$setHeader("Cache-Control", "no-store")  # bearer-credential payload, not cacheable
-  if (!is.null(entry$payload_raw)) unserialize(entry$payload_raw) else entry$payload
+  unserialize(entry$payload_raw)
 }
 
 #* Serve static assets from the ./assets directory

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -206,12 +206,20 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
   # each. Splitting here lets the same endpoint serve single-site (one value)
   # and multisite (several values) requests. Each FIPS code is a separate site
   # (no fipper() expansion), so a list of counties reports as a list of counties.
+  # Parse + validate lat/lon up front so mismatched counts fail cleanly (a 400)
+  # instead of silently recycling (e.g. lat=33 & lon=-112,-114) or erroring 500.
+  latv <- NULL; lonv <- NULL
+  if (identical(method, "latlon")) {
+    latv <- as.numeric(trimws(strsplit(paste(lat, collapse = ","), ",")[[1]]))
+    lonv <- as.numeric(trimws(strsplit(paste(lon, collapse = ","), ",")[[1]]))
+    if (length(latv) != length(lonv)) {
+      res$status <- 400
+      return(handle_error("lat and lon must have the same number of comma-separated values.", "html"))
+    }
+  }
   area <- switch(
     method %||% "",
-    "latlon" = data.frame(
-      lat = as.numeric(trimws(strsplit(paste(lat, collapse = ","), ",")[[1]])),
-      lon = as.numeric(trimws(strsplit(paste(lon, collapse = ","), ",")[[1]]))
-    ),
+    "latlon" = data.frame(lat = latv, lon = lonv),
     "FIPS" = trimws(strsplit(paste(fips, collapse = ","), ",")[[1]]),
     "SHP" = shape,
     NULL
@@ -264,14 +272,14 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
 #* @serializer contentType list(type = "application/octet-stream")
 #* @post /report
 function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, sitenumber = 0, fileextension = "html", scale = NULL, res) {
-  # One method per analysis; auto-detected from which input is present.
-  method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
-  area <- sites %||% shape %||% fips
-
-  if (is.null(method) || is.null(area)) {
+  # One method per analysis; require exactly one input so an ambiguous request
+  # (e.g. both sites and fips) fails cleanly instead of silently picking one.
+  if (sum(!is.null(sites), !is.null(shape), !is.null(fips)) != 1) {
     res$status <- 400
-    return(handle_error("You must provide sites, a shape, or fips.", "html"))
+    return(handle_error("Provide exactly one of sites, shape, or fips.", "html"))
   }
+  method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
+  area <- sites %||% shape %||% fips
 
   # 0 or "overall" -> aggregate multisite report; otherwise the chosen single site.
   sitenum <- if (tolower(as.character(sitenumber)) %in% c("0", "overall")) 0 else suppressWarnings(as.numeric(sitenumber))
@@ -312,7 +320,12 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, sitenumber = 0, fi
 .handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
 
 .handoff_new_token <- function() {
-  paste(sample(c(0:9, letters), 24, replace = TRUE), collapse = "")
+  # Tokens are bearer credentials, so prefer a cryptographically-secure RNG.
+  if (requireNamespace("openssl", quietly = TRUE)) {
+    paste(as.character(openssl::rand_bytes(18)), collapse = "")  # 36 hex chars, CSPRNG
+  } else {
+    paste(sample(c(0:9, letters), 24, replace = TRUE), collapse = "")
+  }
 }
 .handoff_purge_expired <- function() {
   now <- as.numeric(Sys.time())
@@ -343,6 +356,8 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     payload = list(method = method, sites = sites, fips = fips, shape = shape, radius = radius),
     expires = expires
   )
+  # The token is a bearer credential -- don't let it sit in shared/proxy caches.
+  res$setHeader("Cache-Control", "no-store")
   list(token = token, expires = expires)
 }
 
@@ -356,6 +371,7 @@ function(token, res) {
     res$status <- 404
     return(handle_error("Unknown or expired handoff token."))
   }
+  res$setHeader("Cache-Control", "no-store")  # bearer-credential payload, not cacheable
   entry$payload
 }
 

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -159,6 +159,35 @@ function(attribute = "pctunemployed", value=.9, res) {
   return (results)
 }
 
+# Render an ejamit() result as an EJAM report and write it to the plumber
+# response as HTML or PDF. Shared by GET /report (one value per param) and
+# POST /report (JSON body; supports many/large polygons and mixed/large sets).
+# report_title is intentionally left unset so ejam2report() picks the correct
+# header by sitenumber ("EJSCREEN Community Report" vs "EJSCREEN Multisite Summary").
+report_response <- function(result, method, to_map, sitenum, ext, res) {
+  report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"),
+    launch_browser = FALSE, site_method = method, shp = to_map, fileextension = ext)
+
+  if (ext == "html") {
+    res$setHeader("Content-Type", "text/html")
+    res$body <- report_output
+    return(res)
+  }
+
+  # PDF (default). ejam2report() returns a file path or raw bytes.
+  if (is.character(report_output) && file.exists(report_output)) {
+    res$setHeader("Content-Type", "application/pdf")
+    res$setHeader("Content-Disposition", "inline; filename=ejscreen_report.pdf")
+    file_size <- file.info(report_output)$size
+    res$body <- readBin(report_output, "raw", n = file_size)
+    on.exit(unlink(report_output), add = TRUE)
+    return(res)
+  }
+  res$setHeader("Content-Type", "application/pdf")
+  res$body <- report_output
+  res
+}
+
 #* Generate an EJAM report
 #* @param lat Latitude of the site
 #* @param lon Longitude of the site
@@ -219,43 +248,54 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
     to_map$ejam_uniq_id <- seq_len(nrow(to_map)) # one id per feature (multisite-safe)
   }
 
-  # Generate and return the report. Leave report_title unset so ejam2report()
-  # chooses the correct header itself based on sitenumber: the EJAM defaults are
-  # "EJSCREEN Community Report" for a single site and "EJSCREEN Multisite Summary"
-  # for the aggregate (sitenumber = 0). See ejam2report()'s report_title /
-  # report_title_multisite handling.
-  ext <- tolower(fileextension)
-  report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"), launch_browser = FALSE, site_method = method, shp=to_map,
-    fileextension=ext)
+  # Generate and return the report (HTML or PDF). See report_response() above.
+  report_response(result, method, to_map, sitenum, tolower(fileextension), res)
+}
 
-  if (ext == "html") {
-    res$setHeader("Content-Type", "text/html")
-    res$body <- report_output
-    return(res)
-  } 
-  
-  if (ext == "pdf") {
-    # If report_output is a file path, we read it as RAW binary
-    if (is.character(report_output) && file.exists(report_output)) {
-      
-      res$setHeader("Content-Type", "application/pdf")
-      res$setHeader("Content-Disposition", "inline; filename=ejscreen_report.pdf")
-      
-      # Read the file as raw binary data to avoid 'embedded nul' issues
-      file_size <- file.info(report_output)$size
-      res$body <- readBin(report_output, "raw", n = file_size)
-      
-      # Clean up the temp file after reading it into memory
-      on.exit(unlink(report_output), add = TRUE)
-      
-      return(res)
-    } else {
-      # If ejam2report already returned raw bytes, just pass them through
-      res$setHeader("Content-Type", "application/pdf")
-      res$body <- report_output
-      return(res)
-    }
+#* Generate an EJAM report from a POST body (supports many/large polygons and mixed/large site sets).
+#* Same report engine as GET /report, but inputs travel in the request body so there is no URL-length limit.
+#* @param sites An array of {lat, lon} site objects
+#* @param shape A GeoJSON FeatureCollection string (one or more polygons)
+#* @param fips An array of FIPS codes (each one a separate site)
+#* @param buffer The buffer radius in miles (out from a polygon edge, or around a point)
+#* @param sitenumber Which site to report on. Defaults to 0 = aggregate MULTISITE report across all sites.
+#* @param fileextension "html" (default) or "pdf"
+#* @param scale For FIPS requests, the unit (blockgroup or county)
+#* @serializer contentType list(type = "application/octet-stream")
+#* @post /report
+function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, sitenumber = 0, fileextension = "html", scale = NULL, res) {
+  # One method per analysis; auto-detected from which input is present.
+  method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
+  area <- sites %||% shape %||% fips
+
+  if (is.null(method) || is.null(area)) {
+    res$status <- 400
+    return(handle_error("You must provide sites, a shape, or fips.", "html"))
   }
+
+  # 0 or "overall" -> aggregate multisite report; otherwise the chosen single site.
+  sitenum <- if (tolower(as.character(sitenumber)) %in% c("0", "overall")) 0 else suppressWarnings(as.numeric(sitenumber))
+  if (is.na(sitenum)) sitenum <- 0
+
+  result <- tryCatch(
+    ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), scale = scale, endpoint = "report"),
+    error = function(e) {
+      res$status <- 400
+      handle_error(e$message, "html")
+    }
+  )
+  if (is.character(result)) {
+    return(result)
+  }
+
+  # Submitted polygon(s) to appear in the report map.
+  to_map <- NULL
+  if (method == "SHP") {
+    to_map <- geojson_sf(area)
+    to_map$ejam_uniq_id <- seq_len(nrow(to_map))
+  }
+
+  report_response(result, method, to_map, sitenum, tolower(fileextension), res)
 }
 
 # ---- Site handoff (token-based) for launching the EJAM app pre-loaded ----

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -337,7 +337,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 .handoff_max_tokens <- .handoff_env_numeric_or_default("HANDOFF_MAX_TOKENS", 64)
 .handoff_max_payload_bytes <- .handoff_env_numeric_or_default("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
-.handoff_token_collision_retries <- 8L
+.handoff_token_collision_retries <- as.integer(.handoff_env_numeric_or_default("HANDOFF_TOKEN_COLLISION_RETRIES", 8))
 
 .handoff_new_token <- function() {
   # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
@@ -378,11 +378,11 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   payload_bytes <- length(payload_raw)
   if (is.finite(.handoff_max_payload_bytes) && payload_bytes > .handoff_max_payload_bytes) {
     res$status <- 413
-    return(handle_error(sprintf("Handoff payload too large (max %d bytes).", as.integer(.handoff_max_payload_bytes))))
+    return(handle_error(sprintf("Handoff payload size %d bytes exceeds limit of %d bytes.", payload_bytes, as.integer(.handoff_max_payload_bytes))))
   }
   if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
     res$status <- 429
-    return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens).", as.integer(.handoff_max_tokens))))
+    return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens). Retry after a short delay; tokens expire after 1 hour.", as.integer(.handoff_max_tokens))))
   }
   token <- NULL
   for (i in seq_len(.handoff_token_collision_retries)) {

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -166,6 +166,13 @@ function(attribute = "pctunemployed", value=.9, res) {
 # report_title is intentionally left unset so ejam2report() picks the correct
 # header by sitenumber ("EJSCREEN Community Report" vs "EJSCREEN Multisite Summary").
 report_response <- function(result, method, to_map, sitenum, ext, res) {
+  ext <- tolower(ext)
+  if (!ext %in% c("html", "pdf")) {
+    res$status <- 400
+    res$setHeader("Content-Type", "text/html")
+    res$body <- handle_error("fileextension must be 'html' or 'pdf'.", "html")
+    return(res)
+  }
   report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"),
     launch_browser = FALSE, site_method = method, shp = to_map, fileextension = ext)
 
@@ -270,10 +277,9 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
 #* @param buffer The buffer radius in miles (out from a polygon edge, or around a point)
 #* @param sitenumber Which site to report on. Defaults to 0 = aggregate MULTISITE report across all sites.
 #* @param fileextension "html" (default) or "pdf"
-#* @param scale For FIPS requests, the unit (blockgroup or county)
 #* @serializer contentType list(type = "application/octet-stream")
 #* @post /report
-function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sitenumber = 0, fileextension = "html", scale = NULL, res) {
+function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sitenumber = 0, fileextension = "html", res) {
   if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # One method per analysis; require exactly one input so an ambiguous request
   # (e.g. both sites and fips) fails cleanly instead of silently picking one.
@@ -289,7 +295,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
   if (is.na(sitenum)) sitenum <- 0
 
   result <- tryCatch(
-    ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), scale = scale, endpoint = "report"),
+    ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), endpoint = "report"),
     error = function(e) {
       res$status <- 400
       handle_error(e$message, "html")
@@ -323,12 +329,12 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 .handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
 
 .handoff_new_token <- function() {
-  # Tokens are bearer credentials, so prefer a cryptographically-secure RNG.
-  if (requireNamespace("openssl", quietly = TRUE)) {
-    paste(as.character(openssl::rand_bytes(18)), collapse = "")  # 36 hex chars, CSPRNG
-  } else {
-    paste(sample(c(0:9, letters), 24, replace = TRUE), collapse = "")
+  # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
+  # fail fast rather than silently fall back to a guessable token.
+  if (!requireNamespace("openssl", quietly = TRUE)) {
+    stop("The 'openssl' package is required to mint secure handoff tokens.")
   }
+  paste(as.character(openssl::rand_bytes(18)), collapse = "")  # 36 hex chars, CSPRNG
 }
 .handoff_purge_expired <- function() {
   now <- as.numeric(Sys.time())
@@ -355,7 +361,7 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
   }
   token   <- .handoff_new_token()
-  expires <- as.numeric(Sys.time()) + .handoff_ttl_secs
+  expires <- floor(as.numeric(Sys.time())) + .handoff_ttl_secs  # integer epoch seconds
   .handoff_store[[token]] <- list(
     payload = list(method = method, sites = sites, fips = fips, shape = shape, radius = radius),
     expires = expires

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -78,6 +78,26 @@ ejamit_interface <- function(area, method, buffer = 0, scale = "blockgroup", end
   )
 }
 
+#* CORS support so browser apps (e.g. EJScreen) can fetch()/POST cross-origin.
+#* The single-site report flow uses a top-level window.open() GET and needs no
+#* CORS, but the /handoff POST and any future POST endpoints do. Public data API,
+#* so origin is open; tighten to specific origins here if ever needed.
+#* @filter cors
+function(req, res) {
+  res$setHeader("Access-Control-Allow-Origin", "*")
+  if (identical(req$REQUEST_METHOD, "OPTIONS")) {
+    # Respond to the CORS preflight request directly.
+    res$setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+    res$setHeader(
+      "Access-Control-Allow-Headers",
+      req$HTTP_ACCESS_CONTROL_REQUEST_HEADERS %||% "Content-Type"
+    )
+    res$status <- 200L
+    return(list())
+  }
+  plumber::forward()
+}
+
 #* Return EJAM analysis data as JSON based on geography
 #* @param sites A data frame of site coordinates (lat/lon)
 #* @param shape A GeoJSON string representing the area of interest
@@ -145,20 +165,39 @@ function(attribute = "pctunemployed", value=.9, res) {
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
 #* @param buffer The buffer radius in miles
-#* @param sitenumber Which site, in a multi-site analysis, to run a report for. Defaults to 1.
+#* @param sitenumber Which site to report on. Defaults to 1 (single-site). Use 0 (or "overall") for an aggregate MULTISITE report across all sites.
 #* @param fileextension Whether to return a PDF or HTML file. Defaults to PDF.
 #* @serializer contentType list(type = "application/octet-stream")
 #* @get /report
 function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumber=1, fileextension="pdf", res) {
   # Determine the input method and prepare the area.
   method <- if (!is.null(lat) && !is.null(lon)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
-  area <- if (method == "latlon") data.frame(lat = as.numeric(lat), lon = as.numeric(lon)) else shape %||% fips
-  
+
+  # Multisite support: lat/lon and fips may be comma-separated lists, one site
+  # each. Splitting here lets the same endpoint serve single-site (one value)
+  # and multisite (several values) requests. Each FIPS code is a separate site
+  # (no fipper() expansion), so a list of counties reports as a list of counties.
+  area <- switch(
+    method %||% "",
+    "latlon" = data.frame(
+      lat = as.numeric(trimws(strsplit(paste(lat, collapse = ","), ",")[[1]])),
+      lon = as.numeric(trimws(strsplit(paste(lon, collapse = ","), ",")[[1]]))
+    ),
+    "FIPS" = trimws(strsplit(paste(fips, collapse = ","), ",")[[1]]),
+    "SHP" = shape,
+    NULL
+  )
+
   if (is.null(method) || is.null(area)) {
     res$status <- 400
     return(handle_error("You must provide valid coordinates, a shape, or a FIPS code.", "html"))
   }
-  
+
+  # Normalize sitenumber. 0 or "overall" -> aggregate multisite report
+  # (ejam2report renders results_overall); otherwise a single site.
+  sitenum <- if (tolower(as.character(sitenumber)) %in% c("0", "overall")) 0 else suppressWarnings(as.numeric(sitenumber))
+  if (is.na(sitenum)) sitenum <- 1
+
   # Perform the EJAM analysis.
   result <- tryCatch(
     ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), endpoint="report"),
@@ -173,17 +212,18 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
     return(result)
   }
   
-  # Get submitted polygon shape to appear in report map.
+  # Get submitted polygon shape(s) to appear in report map.
   to_map<-NULL # Clear any previous maps
   if (method == "SHP"){
     to_map<-geojson_sf(area) # TBD: get this returned from ejamit_interface
-    to_map$ejam_uniq_id <- 1 # Might run into issues here for multisite reports
+    to_map$ejam_uniq_id <- seq_len(nrow(to_map)) # one id per feature (multisite-safe)
   }
 
   # Generate and return the report.
   ext <- tolower(fileextension)
-  report_output <- ejam2report(result, sitenumber = sitenumber, return_html = (ext == "html"), launch_browser = FALSE, site_method = method, shp=to_map,
-    report_title="EJSCREEN Community Report", fileextension=ext)
+  rpt_title <- if (sitenum == 0) "EJSCREEN Multisite Report" else "EJSCREEN Community Report"
+  report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"), launch_browser = FALSE, site_method = method, shp=to_map,
+    report_title=rpt_title, fileextension=ext)
 
   if (ext == "html") {
     res$setHeader("Content-Type", "text/html")
@@ -213,6 +253,67 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
       return(res)
     }
   }
+}
+
+# ---- Site handoff (token-based) for launching the EJAM app pre-loaded ----
+# An external app (e.g. EJScreen) POSTs a set of selected places and gets back a
+# short token; it then opens the EJAM app at  ...?handoff=<token>  and the app
+# fetches GET /handoff/<token> to pre-load those places. This avoids URL-length
+# limits when handing off polygons.
+#
+# NOTE: this draft uses a simple in-process store with a TTL. On Cloud Run with
+# more than one instance, a token created on instance A may not resolve on
+# instance B. For production use a shared store (GCS object / Firestore / Redis)
+# or run the service with min-instances=1 and a single max instance.
+.handoff_store    <- new.env(parent = emptyenv())
+.handoff_ttl_secs <- 60 * 60  # tokens live for 1 hour
+
+.handoff_new_token <- function() {
+  paste(sample(c(0:9, letters), 24, replace = TRUE), collapse = "")
+}
+.handoff_purge_expired <- function() {
+  now <- as.numeric(Sys.time())
+  for (k in ls(.handoff_store)) {
+    if (.handoff_store[[k]]$expires < now) rm(list = k, envir = .handoff_store)
+  }
+}
+
+#* Store a set of selected sites for handoff to the EJAM app; returns a token.
+#* @param method One of "latlon", "FIPS", or "SHP" (optional; inferred if omitted)
+#* @param sites Array of {lat, lon} site objects
+#* @param fips Array of FIPS codes (each one a separate site)
+#* @param shape A GeoJSON FeatureCollection of polygons
+#* @param radius Buffer radius in miles
+#* @post /handoff
+function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, res) {
+  .handoff_purge_expired()
+  if (is.null(sites) && is.null(fips) && is.null(shape)) {
+    res$status <- 400
+    return(handle_error("Provide sites, fips, or shape to hand off."))
+  }
+  if (is.null(method)) {
+    method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
+  }
+  token   <- .handoff_new_token()
+  expires <- as.numeric(Sys.time()) + .handoff_ttl_secs
+  .handoff_store[[token]] <- list(
+    payload = list(method = method, sites = sites, fips = fips, shape = shape, radius = radius),
+    expires = expires
+  )
+  list(token = token, expires = expires)
+}
+
+#* Retrieve a previously stored handoff payload by token.
+#* @param token The handoff token returned by POST /handoff
+#* @get /handoff/<token>
+function(token, res) {
+  .handoff_purge_expired()
+  entry <- .handoff_store[[token]]
+  if (is.null(entry)) {
+    res$status <- 404
+    return(handle_error("Unknown or expired handoff token."))
+  }
+  entry$payload
 }
 
 #* Serve static assets from the ./assets directory

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -337,6 +337,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 .handoff_max_tokens <- .handoff_env_num_or("HANDOFF_MAX_TOKENS", 64)
 .handoff_max_payload_bytes <- .handoff_env_num_or("HANDOFF_MAX_PAYLOAD_BYTES", 1048576)  # 1 MiB
+.handoff_active_tokens <- 0L
 
 .handoff_new_token <- function() {
   # Tokens are bearer credentials, so REQUIRE a cryptographically-secure RNG --
@@ -348,8 +349,15 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 }
 .handoff_purge_expired <- function() {
   now <- as.numeric(Sys.time())
+  removed <- 0L
   for (k in ls(.handoff_store)) {
-    if (.handoff_store[[k]]$expires < now) rm(list = k, envir = .handoff_store)
+    if (.handoff_store[[k]]$expires < now) {
+      rm(list = k, envir = .handoff_store)
+      removed <- removed + 1L
+    }
+  }
+  if (removed > 0L) {
+    .handoff_active_tokens <<- max(0L, .handoff_active_tokens - removed)
   }
 }
 
@@ -371,21 +379,24 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
     method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
   }
   payload <- list(method = method, sites = sites, fips = fips, shape = shape, radius = radius)
-  payload_bytes <- length(serialize(payload, connection = NULL))
+  payload_raw <- serialize(payload, connection = NULL)
+  payload_bytes <- length(payload_raw)
   if (is.finite(.handoff_max_payload_bytes) && payload_bytes > .handoff_max_payload_bytes) {
     res$status <- 413
     return(handle_error(sprintf("Handoff payload too large (max %d bytes).", as.integer(.handoff_max_payload_bytes))))
   }
-  if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
+  if (is.finite(.handoff_max_tokens) && .handoff_active_tokens >= .handoff_max_tokens) {
     res$status <- 429
     return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens).", as.integer(.handoff_max_tokens))))
   }
   token   <- .handoff_new_token()
+  while (!is.null(.handoff_store[[token]])) token <- .handoff_new_token()
   expires <- floor(as.numeric(Sys.time())) + .handoff_ttl_secs  # integer epoch seconds
   .handoff_store[[token]] <- list(
-    payload = payload,
+    payload_raw = payload_raw,
     expires = expires
   )
+  .handoff_active_tokens <<- .handoff_active_tokens + 1L
   # The token is a bearer credential -- don't let it sit in shared/proxy caches.
   res$setHeader("Cache-Control", "no-store")
   list(token = token, expires = expires)
@@ -402,7 +413,7 @@ function(token, res) {
     return(handle_error("Unknown or expired handoff token."))
   }
   res$setHeader("Cache-Control", "no-store")  # bearer-credential payload, not cacheable
-  entry$payload
+  if (!is.null(entry$payload_raw)) unserialize(entry$payload_raw) else entry$payload
 }
 
 #* Serve static assets from the ./assets directory

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -221,6 +221,10 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
   if (identical(method, "latlon")) {
     latv <- as.numeric(trimws(strsplit(paste(lat, collapse = ","), ",")[[1]]))
     lonv <- as.numeric(trimws(strsplit(paste(lon, collapse = ","), ",")[[1]]))
+    if (anyNA(latv) || anyNA(lonv)) {
+      res$status <- 400
+      return(handle_error("lat and lon must contain only numeric comma-separated values.", "html"))
+    }
     if (length(latv) != length(lonv)) {
       res$status <- 400
       return(handle_error("lat and lon must have the same number of comma-separated values.", "html"))

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -219,11 +219,14 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
     to_map$ejam_uniq_id <- seq_len(nrow(to_map)) # one id per feature (multisite-safe)
   }
 
-  # Generate and return the report.
+  # Generate and return the report. Leave report_title unset so ejam2report()
+  # chooses the correct header itself based on sitenumber: the EJAM defaults are
+  # "EJSCREEN Community Report" for a single site and "EJSCREEN Multisite Summary"
+  # for the aggregate (sitenumber = 0). See ejam2report()'s report_title /
+  # report_title_multisite handling.
   ext <- tolower(fileextension)
-  rpt_title <- if (sitenum == 0) "EJSCREEN Multisite Report" else "EJSCREEN Community Report"
   report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"), launch_browser = FALSE, site_method = method, shp=to_map,
-    report_title=rpt_title, fileextension=ext)
+    fileextension=ext)
 
   if (ext == "html") {
     res$setHeader("Content-Type", "text/html")

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -106,7 +106,8 @@ function(req, res) {
 #* @param geometries A boolean to indicate whether to include geometries in the output
 #* @param scale The Census geography at which to return results (blockgroup or county)
 #* @post /data
-function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE, scale = NULL, res) {
+function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, geometries = FALSE, scale = NULL, res) {
+  if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # Determine the input method.
   method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
   area <- sites %||% shape %||% fips
@@ -198,7 +199,8 @@ report_response <- function(result, method, to_map, sitenum, ext, res) {
 #* @param fileextension Whether to return a PDF or HTML file. Defaults to PDF.
 #* @serializer contentType list(type = "application/octet-stream")
 #* @get /report
-function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumber=1, fileextension="pdf", res) {
+function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius = NULL, sitenumber=1, fileextension="pdf", res) {
+  if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # Determine the input method and prepare the area.
   method <- if (!is.null(lat) && !is.null(lon)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
 
@@ -271,7 +273,8 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
 #* @param scale For FIPS requests, the unit (blockgroup or county)
 #* @serializer contentType list(type = "application/octet-stream")
 #* @post /report
-function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, sitenumber = 0, fileextension = "html", scale = NULL, res) {
+function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sitenumber = 0, fileextension = "html", scale = NULL, res) {
+  if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # One method per analysis; require exactly one input so an ambiguous request
   # (e.g. both sites and fips) fails cleanly instead of silently picking one.
   if (sum(!is.null(sites), !is.null(shape), !is.null(fips)) != 1) {
@@ -341,7 +344,8 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, sitenumber = 0, fi
 #* @param shape A GeoJSON FeatureCollection of polygons
 #* @param radius Buffer radius in miles
 #* @post /handoff
-function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, res) {
+function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, buffer = NULL, res) {
+  if (is.null(radius)) {radius <- buffer}  # buffer is a synonym (alias) for radius
   .handoff_purge_expired()
   if (is.null(sites) && is.null(fips) && is.null(shape)) {
     res$status <- 400

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -374,11 +374,11 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   payload_bytes <- length(serialize(payload, connection = NULL))
   if (is.finite(.handoff_max_payload_bytes) && payload_bytes > .handoff_max_payload_bytes) {
     res$status <- 413
-    return(handle_error(sprintf("Handoff payload too large (max %s bytes).", as.integer(.handoff_max_payload_bytes))))
+    return(handle_error(sprintf("Handoff payload too large (max %d bytes).", as.integer(.handoff_max_payload_bytes))))
   }
   if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
     res$status <- 429
-    return(handle_error(sprintf("Handoff token capacity reached (max %s active tokens).", as.integer(.handoff_max_tokens))))
+    return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens).", as.integer(.handoff_max_tokens))))
   }
   token   <- .handoff_new_token()
   expires <- floor(as.numeric(Sys.time())) + .handoff_ttl_secs  # integer epoch seconds


### PR DESCRIPTION
### These three core feature PRs ([#36 in EJAM-API](https://github.com/Public-Environmental-Data-Partners/EJAM-API/pull/36), [#413 in EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/413), [#66 in EJScreen](https://github.com/Public-Environmental-Data-Partners/EJScreen/pull/66)) let users click on EJScreen maps to pick sites for a multisite report (generated via API), plus let users launch EJAM with those already-specified sites.

The goal of this set of related PRs in 3 repositories is to let EJScreen users select &gt;1 location (points, or polygons or census units) just by clicking right on the familiar EJScreen map, and then obtain an EJAM-style multisite report directly from EJScreen (or launch EJAM with those already-specified sites). Using EJAM's UI to pick sites is better for site selection that is complicated or includes many sites, such as via uploaded file or picking a whole industry type. But unlike EJscreen, the EJAM UI 1) did not provide a way to click on a map to specify a few points and 2) did not provide a way to draw a couple of polygons on the map to specify areas and 3) did not provide a way to click on a block group or county on the map to specify FIPS. 

----
Implements the API side of EJScreen multisite selection.

## What changed (`rest_controller.r`)
- **Multisite `GET /report`** — `lat`/`lon` and `fips` may now be comma-separated lists, one site each (previously these 500'd). `sitenumber=0` (or `overall`) renders an **aggregate multisite report** via EJAM's existing `ejam2report(..., sitenumber = 0)` path (`results_overall`); the default stays `1`, so existing single-site EJScreen calls are unchanged. Each FIPS code is a **separate site** (no `fipper()` expansion), per the agreed design. The report **title is left to `ejam2report()`**, which already picks "EJSCREEN Community Report" (single site) vs "EJSCREEN Multisite Summary" (aggregate) from its `report_title`/`report_title_multisite` defaults — the previous hardcoded `report_title` was dropped (it mislabeled multisite reports). Lat/lon validation now rejects mismatched counts and non-numeric values with a 400 before analysis.
- **Token handoff** — `POST /handoff` stores a set of selected places (`sites`/`fips`/`shape`/`radius`) and returns `{token, expires}`; `GET /handoff/<token>` returns it. Lets EJScreen open the EJAM app at `?handoff=<token>` and pre-load places without URL-length limits (key for polygons). The in-process TTL store now has **bounded limits**: configurable max payload size (`HANDOFF_MAX_PAYLOAD_BYTES`, default 1 MiB), configurable max active tokens (`HANDOFF_MAX_TOKENS`, default 64), and bounded token-collision retries (`HANDOFF_TOKEN_COLLISION_RETRIES`, default 8), with explicit error responses when limits are exceeded.
- **CORS** — `@filter cors` adds `Access-Control-Allow-Origin: *` and answers `OPTIONS` preflight so the browser `fetch()`/POST to `/handoff` works cross-origin.

## `Dockerfile`
- when ready, should bump the EJAM tag **v2.32.8.1 → v3.2022.0 or v3.2022.1 or development** 

## Scope / follow-ups
- Multisite reports: **GET /report** serves points/FIPS (URL-friendly); **POST /report** (added) serves many/large polygons and large site sets via a JSON body — same report engine, shared `report_response()` helper. POST `/report` currently accepts exactly one input type per request (`sites` OR `shape` OR `fips`).
- Production handoff store (GCS/Firestore) is still a follow-up; the current in-process path now includes bounded safeguards to reduce memory-risk exposure.

## Testing notes
- `rest_controller.r` parses cleanly. Not yet run against a live EJAM v3.2022.0 image — needs a build + smoke test of: `GET /report?fips=10001,10003&sitenumber=0&fileextension=html`, `GET /report?lat=33,34&lon=-112,-114&sitenumber=0`, malformed lat/lon rejection (e.g. `lat=33,bad&lon=-112,-114`), handoff limit behavior (oversize payload / token-capacity responses), single-site regression, a `POST /handoff` → `GET /handoff/<token>` round-trip, and a `POST /report` multisite render (points, FIPS, and a multi-polygon FeatureCollection).

Part of the cross-repo feature (EJScreen #65). Design: `planning/ejscreen-multisite-selection-plan.md` on EJAM branch `ejscreen-multisite-selection`.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>