### PR TITLE
Dockerfile: single-source the EJAM version (ARG EJAM_VERSION) + repo-level override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
 
 # EJAM version: this ARG is the ONE place that sets which tagged EJAM release is installed.
 # Override at build time without editing this file, e.g.:
-#   docker build --build-arg EJAM_VERSION=v3.2024.0 .
+#   docker build --build-arg EJAM_VERSION=v2.2022.0 .
+#   docker build --build-arg EJAM_VERSION=v2.2022.1 .
 # A CI build can supply it from a repo variable (see README "Choosing the EJAM version").
 ARG EJAM_VERSION=v2.32.8.1
 # Record the version in the image so the running API can report which EJAM it was built with.

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,17 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
     chmod +x /usr/local/bin/google-chrome && \
     echo 'CHROMOTE_CHROME=/usr/local/bin/google-chrome' >> /etc/R/Renviron.site
 
-# Clone EJAM
-RUN git clone --branch v2.32.8.1 --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM-2.32.8.1 && \
-    cd /EJAM-2.32.8.1 && \
+# EJAM version: this ARG is the ONE place that sets which tagged EJAM release is installed.
+# Override at build time without editing this file, e.g.:
+#   docker build --build-arg EJAM_VERSION=v3.2024.0 .
+# A CI build can supply it from a repo variable (see README "Choosing the EJAM version").
+ARG EJAM_VERSION=v3.2022.0
+# Record the version in the image so the running API can report which EJAM it was built with.
+ENV EJAM_VERSION=${EJAM_VERSION}
+
+# Clone EJAM into a fixed scratch dir (its name is arbitrary; it is removed after install).
+RUN git clone --branch "${EJAM_VERSION}" --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM_src && \
+    cd /EJAM_src && \
     git lfs pull
 
 # Install Dependencies & EJAM
@@ -56,19 +64,19 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
     options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/__linux__/jammy/latest')); \
     \
     # Pre-install key dependencies first \
-    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr')); \
+    install.packages(c('remotes', 'plumber', 'sf', 'mapview', 'tidycensus', 'magrittr', 'openssl')); \
     \
     # Install a fixed fork of AOI \
     remotes::install_github('ericnost/AOI', upgrade='never'); \
     \
     # Install EJAM using upgrade='never' so it doesn't break the stable environment \
-    remotes::install_local('/EJAM-2.32.8.1', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
+    remotes::install_local('/EJAM_src', dependencies=TRUE, upgrade='never', build=FALSE, INSTALL_opts=c('--preclean', '--no-multiarch', '--with-keep.source')); \
     \
     # Verify installation \
     if (!('EJAM' %in% installed.packages()[, 'Package'])) stop('EJAM FAILED TO INSTALL!'); \
     " && \
     # Clean up the cloned source directory \
-    rm -rf /EJAM-2.32.8.1
+    rm -rf /EJAM_src
 
 # Reset frontend
 ENV DEBIAN_FRONTEND=dialog

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,9 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
 
 # EJAM version: this ARG is the ONE place that sets which tagged EJAM release is installed.
 # Override at build time without editing this file, e.g.:
-#   docker build --build-arg EJAM_VERSION=v2.2022.0 .
-#   docker build --build-arg EJAM_VERSION=v2.2022.1 .
+#   docker build --build-arg EJAM_VERSION=v3.2022.0 .
+#   docker build --build-arg EJAM_VERSION=v3.2022.1 .
+#   docker build --build-arg EJAM_VERSION=v3.2024.0 .
 # A CI build can supply it from a repo variable (see README "Choosing the EJAM version").
 ARG EJAM_VERSION=v2.32.8.1
 # Record the version in the image so the running API can report which EJAM it was built with.

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ARG EJAM_VERSION=v3.2022.0
 # Record the version in the image so the running API can report which EJAM it was built with.
 ENV EJAM_VERSION=${EJAM_VERSION}
 
-# Clone EJAM into a fixed scratch dir (its name is arbitrary; it is removed after install).
+# Clone EJAM into a fixed scratch dir (its name is arbitrary; it is deleted from the container filesystem after install).
 RUN git clone --branch "${EJAM_VERSION}" --depth 1 https://github.com/Public-Environmental-Data-Partners/EJAM.git /EJAM_src && \
     cd /EJAM_src && \
     git lfs pull

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
 # Override at build time without editing this file, e.g.:
 #   docker build --build-arg EJAM_VERSION=v3.2024.0 .
 # A CI build can supply it from a repo variable (see README "Choosing the EJAM version").
-ARG EJAM_VERSION=v3.2022.0
+ARG EJAM_VERSION=v2.32.8.1
 # Record the version in the image so the running API can report which EJAM it was built with.
 ENV EJAM_VERSION=${EJAM_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN echo '#!/bin/bash\nexec /usr/bin/google-chrome-stable --no-sandbox --disable
 # EJAM version: this ARG is the ONE place that sets which tagged EJAM release is installed.
 # Override at build time without editing this file, e.g.:
 #   docker build --build-arg EJAM_VERSION=v3.2022.0 .
-#   docker build --build-arg EJAM_VERSION=v3.2022.1 .
+#   docker build --build-arg EJAM_VERSION=v3.2023.0 .
 #   docker build --build-arg EJAM_VERSION=v3.2024.0 .
 # A CI build can supply it from a repo variable (see README "Choosing the EJAM version").
 ARG EJAM_VERSION=v2.32.8.1

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ df
 
 The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v2.32.8.1`, matching the version the image currently deploys). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v2.32.8.1`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
 
-- **Override at build time** (no Dockerfile edit), e.g. `docker build --build-arg EJAM_VERSION=v2.2022.0 .` or `docker build --build-arg EJAM_VERSION=v2.2022.1 .`
+- **Override at build time** (no Dockerfile edit), e.g. `docker build --build-arg EJAM_VERSION=v3.2022.0 .` or `docker build --build-arg EJAM_VERSION=v3.2022.1 .`
 - **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)
 - The selected version is also recorded in the image as the `EJAM_VERSION` environment variable, so the running API can report which EJAM release it was built with.
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,17 @@ df
 # Set-up
 1. Work locally with EJAM by installing R/RStudio. Follow the [installation instructions](https://ejanalysis.github.io/EJAM/articles/installing.html) in the [EJAM documentation](https://ejanalysis.org/ejamdocs).
 2. Test changes to the API (i.e. modify `rest_controller.r`)
-3. Re-build and tag the Docker image
+3. Re-build and tag the Docker image (the EJAM version is controlled by the `EJAM_VERSION` build arg — see below)
 4. Push to Docker Hub and/or Google Artifact Registry
 5. Re-deploy in Google Cloud Run
+
+## Choosing the EJAM version
+
+The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v3.2022.0`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
+
+- **Override at build time** (no Dockerfile edit): `docker build --build-arg EJAM_VERSION=v3.2024.0 .`
+- **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)
+- The selected version is also recorded in the image as the `EJAM_VERSION` environment variable, so the running API can report which EJAM release it was built with.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ df
 
 ## Choosing the EJAM version
 
-The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v3.2022.0`). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v3.2022.0`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
+The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v2.32.8.1`, matching the version the image currently deploys). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v2.32.8.1`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
 
 - **Override at build time** (no Dockerfile edit): `docker build --build-arg EJAM_VERSION=v3.2024.0 .`
 - **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ df
 
 The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v2.32.8.1`, matching the version the image currently deploys). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v2.32.8.1`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
 
-- **Override at build time** (no Dockerfile edit), e.g. `docker build --build-arg EJAM_VERSION=v3.2022.0 .` or `docker build --build-arg EJAM_VERSION=v3.2022.1 .`
+- **Override at build time** (no Dockerfile edit), e.g. `docker build --build-arg EJAM_VERSION=v3.2022.0 .` or `docker build --build-arg EJAM_VERSION=v3.2023.0 .`
 - **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)
 - The selected version is also recorded in the image as the `EJAM_VERSION` environment variable, so the running API can report which EJAM release it was built with.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ df
 
 The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v2.32.8.1`, matching the version the image currently deploys). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v2.32.8.1`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
 
-- **Override at build time** (no Dockerfile edit): `docker build --build-arg EJAM_VERSION=v3.2024.0 .`
+- **Override at build time** (no Dockerfile edit), e.g. `docker build --build-arg EJAM_VERSION=v2.2022.0 .` or `docker build --build-arg EJAM_VERSION=v2.2022.1 .`
 - **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)
 - The selected version is also recorded in the image as the `EJAM_VERSION` environment variable, so the running API can report which EJAM release it was built with.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ df
 
 ## Choosing the EJAM version
 
-The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v3.2022.0`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
+The version of the [EJAM](https://github.com/Public-Environmental-Data-Partners/EJAM) package baked into the image is set in **one place**: the `EJAM_VERSION` build argument in the [`Dockerfile`](/Dockerfile) (default `v3.2022.0`). This value is passed directly to `git clone --branch`, so it must be a valid git ref (typically a tag like `v3.2022.0`, including the leading `v`). That's the only line to change when bumping versions — the clone uses a fixed scratch directory (`/EJAM_src`), so the version no longer has to be repeated across the clone, install, and cleanup steps.
 
 - **Override at build time** (no Dockerfile edit): `docker build --build-arg EJAM_VERSION=v3.2024.0 .`
 - **Control it at the repo level:** set a GitHub Actions repository variable named `EJAM_VERSION` (Settings → Secrets and variables → Actions → Variables), and have the image-build step pass it through with `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (This repo currently builds the image manually per the steps above; that variable is consumed automatically once an image-build workflow is added.)


### PR DESCRIPTION
Refactors the Dockerfile so the EJAM version is specified in **one place** and can be overridden without editing the file. Also consolidates all Dockerfile changes here so that #36 no longer needs to touch the Dockerfile.

## Problem
The EJAM version was repeated in ~5 spots and in **two forms** — the tag `v…` in `--branch`, and the bare version baked into the `/EJAM-<ver>` temp dir name (used by `clone`, `cd`, `install_local('…')`, and `rm -rf`). Bumping meant editing all of them.

## Change
- **`ARG EJAM_VERSION`** (default `v2.32.8.1`) is now the single source — used only in `git clone --branch "${EJAM_VERSION}"`.
- Clone into a **fixed scratch dir `/EJAM_src`** (deleted after install), so the version no longer appears in the dir name / `install_local` / `rm`.
- **`ENV EJAM_VERSION=${EJAM_VERSION}`** records it in the image (so the running API can report which EJAM it was built with).
- Adds the R **`openssl`** package (CSPRNG for handoff tokens) to the base install — addresses the Dockerfile review comment on #36.
- **README:** new "Choosing the EJAM version" section.

**No EJAM version change:** the default stays at `v2.32.8.1` (the version the image deploys today), so this is a pure single-sourcing refactor. Bumping to a newer release is now a deliberate one-line change to the `ARG` default (or the `EJAM_VERSION` repo variable), to be done after smoke-testing the endpoints against that release.

## Overriding the version
- Build-time: `docker build --build-arg EJAM_VERSION=v3.2022.0 .` or `docker build --build-arg EJAM_VERSION=v3.2023.0 .`
- Repo-level: a GitHub Actions repo **variable** `EJAM_VERSION` (currently set to `v2.32.8.1`) can feed an image-build step via `--build-arg EJAM_VERSION=${{ vars.EJAM_VERSION }}`. (The repo currently builds the image manually per the README; the variable is consumed once an image-build workflow exists.)

## Relationship to #36
This PR **carries all the Dockerfile changes** so #36 can drop its Dockerfile edits and stay focused on `rest_controller.r`/README:
- the single-sourcing refactor above
- installing the R **`openssl`** package (CSPRNG for handoff tokens).

#36 has been updated to revert its Dockerfile — it now changes only `rest_controller.r` and `README.md`. **Deploy note:** build/deploy #38 together with #36 — #36's token minting requires the `openssl` that this PR adds to the image.

## Testing
Static refactor of the build only (no API code change). Not yet built against a live image (image rebuild + Cloud Run redeploy is owned separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)