### PR TITLE
Fix API docs page (/__docs__/) 404 — mount @assets at /assets, not root

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ In February 2025, USEPA removed its EJSCREEN website from public access, includi
 Recreating that API would require extensive reverse engineering of the ArcGIS map server(s) that hosted the API functionality. Instead, our approach is to draw on [EJAM](https://github.com/ejanalysis/EJAM), the non-EPA version of an open-source R package that provides EJSCREEN's "multisite" reporting feature. EJAM was designed to produce EJSCREEN-style community reports, including single-site reports and multisite reports (summaries over multiple locations). The EJAM package itself does not currently provide an API; this repo contains files necessary to create a Docker image of EJAM and its dependencies as well as an API model.
 
 # Model
-There are currently two endpoints for the API.
+The key endpoints for the API are **report** and **data**:
 
 ## Reports
+
+The `report` endpoint returns a PDF or HTML report for one or more sites specified by
+point, area (polygon), or FIPS geography.
+
 `report` accepts GET requests with the following parameters:
 - `lat` - the latitude of a given point, or comma-separated list like lat=33,32.5
 - `lon` - the longitude
@@ -27,6 +31,9 @@ A point in the Phoenix area with a 4 mile buffer (radius): https://ejamapi-84652
 A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652557241.us-central1.run.app/report?shape=%7B"type"%3A"FeatureCollection"%2C"features"%3A%5B%7B"type"%3A"Feature"%2C"properties"%3A%7B%7D%2C"geometry"%3A%7B"coordinates"%3A%5B%5B%5B-112.01991856401462%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.47010908826502%5D%2C%5B-111.95488826248605%2C33.51124624304089%5D%2C%5B-112.01991856401462%2C33.51124624304089%5D%5D%5D%2C"type"%3A"Polygon"%7D%7D%5D%7D&buffer=0
 
 ## Data
+
+The `data` endpoint returns a JSON object of EJAM output for a given point, area, or FIPS geography.
+
 `data` accepts POST requests with the following parameters:
 - `sites` - a list of lat/lon pairs e.g. `[{"lat":33, "lon":-112}, {"lat":34, "lon":-114}]`
 - `shape` - a GeoJSON object describing an area of interest, such as a polygon of neighborhood boundaries
@@ -62,6 +69,12 @@ response = requests.post(url, json=data)
 df = pandas.DataFrame.from_dict(response.json())
 df
 ```
+
+## Assets
+
+An assets endpoint returns a file from a pre-defined set of assets. The endpoint is structured as `/assets/<asset_name>`, 
+where `<asset_name>` is the name of the asset file. 
+For example, to retrieve a specific asset, you would make a GET request to `/assets/example_asset.pdf`.
 
 # Set-up
 1. Work locally with EJAM by installing R/RStudio. Follow the [installation instructions](https://ejanalysis.github.io/EJAM/articles/installing.html) in the [EJAM documentation](https://ejanalysis.org/ejamdocs).

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -93,6 +93,7 @@ ejamit_interface <- function(area, method, buffer = 0, scale = "blockgroup", end
 # /data ####
 
 #* Return EJAM analysis data as JSON based on geography
+#* @tag Data
 #* @param sites A data frame of site coordinates (lat/lon)
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
@@ -141,6 +142,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
 # /query ####
 
 #* Return EJAM analysis data as JSON based on attribute query
+#* @tag Data
 #* @param attribute An EJSCREEN attribute, in EJAM syntax (e.g. pctunemployed)
 #* @param value A decimal, 0-1, representing a cutoff/threshold; returns blockgroups whose percentile rank for the attribute is larger (e.g. pctunemployed > .9)
 #* @post /query
@@ -158,6 +160,7 @@ function(attribute = "pctunemployed", value=.9, res) {
 # /report ####
 
 #* Generate an EJAM report
+#* @tag Reports
 #* @param lat Latitude of the site
 #* @param lon Longitude of the site
 #* @param shape A GeoJSON string representing the area of interest

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -215,6 +215,8 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
   }
 }
 
-#* Serve static assets from the ./assets directory
-#* @assets ./assets /
+#* Serve static assets from the ./assets directory at /assets.
+#* NOTE: do NOT mount at root "/", which shadows plumber's OpenAPI/Swagger
+#* docs UI at /__docs__/ and makes the documentation page return 404.
+#* @assets ./assets /assets
 list()

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -6,6 +6,18 @@ library(geojsonsf)
 library(jsonlite)
 library(sf)
 
+############################# #
+#* @apiTitle API for EJAM / EJSCREEN Data, Analysis, and Reports
+#*
+#* @apiDescription EJSCREEN provides environmental justice screening and mapping.
+#* EJSCREEN's Multisite Tool is called EJAM (Environmental Justice Analysis Multisite).
+#* For information about EJSCREEN, see <https://public-environmental-data-partners.github.io/EJAM/articles/ejscreen.html>.
+#* For technical documentation on EJAM (software powering the API) see
+#* <https://ejanalysis.org/ejamdocs>.
+#* For information on the API itself, see
+#* <https://github.com/Public-Environmental-Data-Partners/EJAM-API#ejam-api>
+############################# #
+
 # Centralized error handling function
 handle_error <- function(message, type = "json") {
   if (type == "html") {
@@ -24,14 +36,14 @@ fipper <- function(area, scale = "blockgroup") {
       return(area)
     }
   )
-  
+
   # Determine the type of the provided FIPS code.
   fips_type <- fipstype(fips_area)[1]
-  
+
   if (fips_type == scale) {
     return(fips_area)
   }
-  
+
   # Convert the FIPS code to the desired scale.
   switch(scale,
          "county" = fips_counties_from_statefips(fips_area),
@@ -47,7 +59,7 @@ ejamit_interface <- function(area, method, buffer = 0, scale = "blockgroup", end
   if (!is.numeric(buffer) || buffer > 15) {
     stop("Please select a buffer of 15 miles or less.")
   }
-  
+
   # Process the request based on the specified method.
   switch(method,
          "latlon" = {
@@ -77,6 +89,8 @@ ejamit_interface <- function(area, method, buffer = 0, scale = "blockgroup", end
          stop("Invalid method specified.") # Handle unrecognized methods.
   )
 }
+# ________________________________ ####
+# /data ####
 
 #* Return EJAM analysis data as JSON based on geography
 #* @param sites A data frame of site coordinates (lat/lon)
@@ -90,12 +104,12 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
   # Determine the input method.
   method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
   area <- sites %||% shape %||% fips
-  
+
   if (is.null(method) || is.null(area)) {
     res$status <- 400
     return(handle_error("You must provide valid points, a shape, or a FIPS code."))
   }
-  
+
   # Perform the EJAM analysis.
   result <- tryCatch(
     ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), scale = scale, endpoint = "data"),
@@ -104,12 +118,12 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
       handle_error(e$message)
     }
   )
-  
+
   # If an error was returned from the interface, return it.
   if ("error" %in% names(result)) {
     return(result)
   }
-  
+
   # Prepare the final JSON output.
   if (geometries) {
     output_shape <- switch(method,
@@ -123,6 +137,8 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, geometries = FALSE
     return(result$results_bysite)
   }
 }
+
+# /query ####
 
 #* Return EJAM analysis data as JSON based on attribute query
 #* @param attribute An EJSCREEN attribute, in EJAM syntax (e.g. pctunemployed)
@@ -139,6 +155,8 @@ function(attribute = "pctunemployed", value=.9, res) {
   return (results)
 }
 
+# /report ####
+
 #* Generate an EJAM report
 #* @param lat Latitude of the site
 #* @param lon Longitude of the site
@@ -153,12 +171,12 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
   # Determine the input method and prepare the area.
   method <- if (!is.null(lat) && !is.null(lon)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
   area <- if (method == "latlon") data.frame(lat = as.numeric(lat), lon = as.numeric(lon)) else shape %||% fips
-  
+
   if (is.null(method) || is.null(area)) {
     res$status <- 400
     return(handle_error("You must provide valid coordinates, a shape, or a FIPS code.", "html"))
   }
-  
+
   # Perform the EJAM analysis.
   result <- tryCatch(
     ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), endpoint="report"),
@@ -167,13 +185,13 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
       handle_error(e$message, "html")
     }
   )
-  
+
   # If an error occurred during the analysis, return the error message.
   if (is.character(result)) {
     return(result)
   }
-  
-  # Get submitted polygon shape to appear in report map.
+
+  # Get submitted polygon shape(s) to appear in report map.
   to_map<-NULL # Clear any previous maps
   if (method == "SHP"){
     to_map<-geojson_sf(area) # TBD: get this returned from ejamit_interface
@@ -189,22 +207,22 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
     res$setHeader("Content-Type", "text/html")
     res$body <- report_output
     return(res)
-  } 
-  
+  }
+
   if (ext == "pdf") {
     # If report_output is a file path, we read it as RAW binary
     if (is.character(report_output) && file.exists(report_output)) {
-      
+
       res$setHeader("Content-Type", "application/pdf")
       res$setHeader("Content-Disposition", "inline; filename=ejscreen_report.pdf")
-      
+
       # Read the file as raw binary data to avoid 'embedded nul' issues
       file_size <- file.info(report_output)$size
       res$body <- readBin(report_output, "raw", n = file_size)
-      
+
       # Clean up the temp file after reading it into memory
       on.exit(unlink(report_output), add = TRUE)
-      
+
       return(res)
     } else {
       # If ejam2report already returned raw bytes, just pass them through
@@ -214,6 +232,8 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, sitenumb
     }
   }
 }
+
+# /assets ####
 
 #* Serve static assets from the ./assets directory at /assets.
 #* NOTE: do NOT mount at root "/", which shadows plumber's OpenAPI/Swagger


### PR DESCRIPTION
## Problem

The API serves its endpoints fine and `/openapi.json` returns the spec, but the **interactive documentation page never renders** — `GET /__docs__/` (and the legacy `/__swagger__/`) returns:

```
{"error":"404 - Resource Not Found"}
```

This happens both on a **local run** and on the **deployed service**, so users can't browse the endpoints/parameters from the built-in docs page.

## Cause

The static-asset directive at the end of `rest_controller.r`:

```r
#* @assets ./assets /
```

mounts the static file handler at the **root path `/`**. That root mount **shadows plumber's Swagger UI mount at `/__docs__/`**: a request for `/__docs__/` is routed into the static handler, which looks for a file `./assets/__docs__/…`, doesn't find one, and returns 404. (`/openapi.json` is unaffected because it's a higher-precedence endpoint — which is exactly why the spec works but the docs page doesn't.)

This is not a plumber/swagger version issue. Confirmed by an A/B test on the same server, changing only the mount path:

| `@assets` mount | `GET /__docs__/` |
|---|---|
| `./assets /` (root) | **404** |
| `./assets /assets` | **200** (Swagger UI renders) |

## Fix

Mount the assets at `/assets` instead of `/`. The docs page renders at `/__docs__/` as expected, and the static files remain available — just under `/assets/`:

- `GET /__docs__/` → **200** (interactive API docs)
- `GET /assets/communityreport.css` → **200** (24,165 bytes, served as before)

The generated reports are self-contained (CSS embedded as `<style>` / `data:` URIs — zero references to `communityreport.css` or the `/assets` path), so report output is unaffected. A comment is added at the directive warning against re-mounting at root.

## Test

Run the API and open `http://127.0.0.1:8080/__docs__/` — it now shows the documentation page listing every endpoint and parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)