### PR TITLE
Speed up report delivery: bake EJAM data into the image + edge-cacheable GET /report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,16 +90,24 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
 # data/ejamdata_version.txt marker, so the runtime attach finds everything
 # up-to-date and skips all downloads (measured: this download is the dominant
 # cold-start cost -- see Public-Environmental-Data-Partners/EJAM#293).
-# Needs network during build; downloads are unauthenticated (fine from a build
-# machine; export GITHUB_PAT in the build environment only if rate-limited).
-# The build FAILS if the files or the version marker did not land.
-RUN R -e " \
+# Needs network during build; downloads are unauthenticated. If the build
+# machine is GitHub-rate-limited, pass a token as a BuildKit secret (NOT a
+# build arg or ENV, so it is never baked into an image layer):
+#   docker build --secret id=github_pat,env=GITHUB_PAT ...
+# (Requires BuildKit -- the default builder in Docker 23+, or DOCKER_BUILDKIT=1.
+# The secret is optional: without it the download runs unauthenticated as before.)
+# The build FAILS if the files or the version marker did not land. The check
+# requires the version marker plus at least one arrow file (not a hardcoded
+# count, which would break when a data release changes how files are sharded).
+RUN --mount=type=secret,id=github_pat \
+    if [ -f /run/secrets/github_pat ]; then export GITHUB_PAT="$(cat /run/secrets/github_pat)"; fi; \
+    R -e " \
     library(EJAM); \
     dd <- system.file('data', package = 'EJAM'); \
     arrows <- list.files(dd, pattern = '[.]arrow\$'); \
     marker <- file.exists(file.path(dd, 'ejamdata_version.txt')); \
     cat('arrow files baked into image:', length(arrows), '| version marker present:', marker, '\n'); \
-    if (length(arrows) < 11 || !marker) stop('DATA BAKE FAILED: arrow files or version marker missing'); \
+    if (length(arrows) < 1 || !marker) stop('DATA BAKE FAILED: arrow files or version marker missing'); \
     "
 
 # Reset frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,25 @@ RUN MAKEFLAGS="-j$(nproc)" R -e " \
     # Clean up the cloned source directory \
     rm -rf /EJAM_src
 
+# Bake the EJAM arrow datasets (~1 GB) into the image so containers do NOT
+# download them from GitHub at every cold start. library(EJAM) here triggers
+# the exact .onAttach download that would otherwise run at container startup;
+# it saves the files into the installed package's data folder and writes the
+# data/ejamdata_version.txt marker, so the runtime attach finds everything
+# up-to-date and skips all downloads (measured: this download is the dominant
+# cold-start cost -- see Public-Environmental-Data-Partners/EJAM#293).
+# Needs network during build; downloads are unauthenticated (fine from a build
+# machine; export GITHUB_PAT in the build environment only if rate-limited).
+# The build FAILS if the files or the version marker did not land.
+RUN R -e " \
+    library(EJAM); \
+    dd <- system.file('data', package = 'EJAM'); \
+    arrows <- list.files(dd, pattern = '[.]arrow\$'); \
+    marker <- file.exists(file.path(dd, 'ejamdata_version.txt')); \
+    cat('arrow files baked into image:', length(arrows), '| version marker present:', marker, '\n'); \
+    if (length(arrows) < 11 || !marker) stop('DATA BAKE FAILED: arrow files or version marker missing'); \
+    "
+
 # Reset frontend
 ENV DEBIAN_FRONTEND=dialog
 

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -51,6 +51,9 @@ handle_error <- function(message, type = "json") {
 html_error <- function(res, status, message) {
   res$status <- status
   res$setHeader("Content-Type", "text/html")
+  # Never let an error page be cached at the edge (successful GET /report
+  # responses are cacheable -- see report_response()).
+  res$setHeader("Cache-Control", "no-store")
   res$body <- handle_error(message, "html")
   res
 }
@@ -228,16 +231,26 @@ function(attribute = "pctunemployed", value=.9, res) {
 # POST /report (JSON body; supports many/large polygons and mixed/large sets).
 # report_title is intentionally left unset so ejam2report() picks the correct
 # header by sitenumber ("EJSCREEN Community Report" vs "EJSCREEN Multisite Summary").
-report_response <- function(result, method, to_map, sitenum, ext, res) {
+report_response <- function(result, method, to_map, sitenum, ext, res, cache_header = NULL) {
   ext <- tolower(ext)
   if (!ext %in% c("html", "pdf")) {
     res$status <- 400
     res$setHeader("Content-Type", "text/html")
+    res$setHeader("Cache-Control", "no-store")
     res$body <- handle_error("fileextension must be 'html' or 'pdf'.", "html")
     return(res)
   }
   report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"),
     launch_browser = FALSE, site_method = method, shp = to_map, fileextension = ext)
+
+  # Successful reports are deterministic for a given URL + deployed data
+  # release, so GET responses are marked edge-cacheable (the Cloudflare proxy
+  # at api.ejanalysis.com can then serve repeat requests instantly instead of
+  # recomputing for 13-45+ seconds). POST responses pass cache_header = NULL
+  # and are never cached.
+  if (!is.null(cache_header)) {
+    res$setHeader("Cache-Control", cache_header)
+  }
 
   if (ext == "html") {
     res$setHeader("Content-Type", "text/html")
@@ -329,7 +342,11 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
   }
 
   # Generate and return the report (HTML or PDF). See report_response() above.
-  report_response(result, method, to_map, sitenum, tolower(fileextension), res)
+  # GET responses are cacheable (deterministic per URL + data release); 1 day
+  # keeps repeat clicks fast while limiting staleness after a redeploy. (Purge
+  # the Cloudflare cache, or bump the data release, when redeploying.)
+  report_response(result, method, to_map, sitenum, tolower(fileextension), res,
+                  cache_header = "public, max-age=86400")
 }
 
 #* Generate an EJAM report from a POST body (supports many/large polygons and mixed/large site sets).

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -247,10 +247,8 @@ report_response <- function(result, method, to_map, sitenum, ext, res, cache_hea
   # release, so GET responses are marked edge-cacheable (the Cloudflare proxy
   # at api.ejanalysis.com can then serve repeat requests instantly instead of
   # recomputing for 13-45+ seconds). POST responses pass cache_header = NULL
-  # and are never cached.
-  if (!is.null(cache_header)) {
-    res$setHeader("Cache-Control", cache_header)
-  }
+  # and get an explicit no-store so no intermediary caches them.
+  res$setHeader("Cache-Control", if (is.null(cache_header)) "no-store" else cache_header)
 
   if (ext == "html") {
     res$setHeader("Content-Type", "text/html")


### PR DESCRIPTION
Two changes so the API can hand a user their report much sooner. No change to report content or parameter defaults.

**1. Bake the EJAM data into the Docker image (fixes the slow cold start).** Today, every new container instance downloads ~1 GB of ejamdata arrow files from GitHub inside `library(EJAM)` **before plumber can even open its port** — measured as the dominant cold-start cost (a cold instance can be unresponsive for minutes; the first user after a quiet period sees a blank tab — Public-Environmental-Data-Partners/EJAM#293). The Dockerfile now runs `library(EJAM)` at **build** time, so the files and the `ejamdata_version.txt` marker are already in the image and startup skips all downloads: a cold start shrinks to roughly image pull + package attach. The build fails loudly if the bake didn't land. (Image grows ~1 GB; build needs network.)

**2. Edge-cacheable GET /report (makes repeat reports instant).** A report is deterministic for a given URL + deployed data release, but today a repeat of the same URL recomputes for 13–45+ s. Successful GET /report responses now send `Cache-Control: public, max-age=86400`, so the Cloudflare proxy (api.ejanalysis.com — see Public-Environmental-Data-Partners/EJAM#447) can serve repeats from the edge in milliseconds. Error pages and POST responses are never cached.

Companion PRs: Public-Environmental-Data-Partners/EJAM#447 (route links through the proxy), Public-Environmental-Data-Partners/EJAM-API companion for report-format defaults (separate PR), and the caching design in Public-Environmental-Data-Partners/EJAM#446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)