### PR TITLE
Default report format: html for multisite reports (much faster), pdf for single-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ point, area (polygon), or FIPS geography.
 - `shape` - a GeoJSON text-encoded object describing an area of interest, such as a polygon of neighborhood boundaries
 - `buffer` (or `radius`, a synonym) - radius, in miles, around a point or out from the edge of a polygon to extend the search. EJAM default = 3. *Note: adding buffers around fips units may not be implemented yet.
 - `sitenumber` - which site to report on when more than one is supplied. Default = 1 (a single-site report on the first site). Use `sitenumber=0` (or `sitenumber=overall`) to get an aggregate **multisite report** that summarizes all of the supplied sites together. Each comma-separated `fips` code is treated as a separate site (no expansion), so `fips=10001,10003&sitenumber=0` reports on those two counties together.
-- `fileextension` - `pdf` (default) or `html`.
+- `fileextension` - `html` or `pdf`. Default if omitted: `pdf` for a single-site report (better page breaks when printing), `html` for a multisite report (`sitenumber=0`/`overall`) -- HTML is generated much faster, and its interactive map lets you click any site's point to open that site's own report.
 
-`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. With `fileextension=html`, an HTML report is returned; otherwise a PDF.
+`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. If `fileextension` is omitted, a single-site report is returned as PDF and a multisite report as HTML; pass `fileextension` explicitly to override.
 
 ### Examples
 A report on one county: https://api.ejanalysis.com/report?fips=10001
@@ -51,7 +51,7 @@ A rectangular area of interest in Phoenix, with no buffer: https://ejamapi-84652
 
 `report` also accepts **POST** requests, for multisite reports over **many or large polygons** (or large site sets) that would not fit in a GET URL. It uses the same report engine and accepts `sites`, `shape`, `fips`, and `buffer` (like `data`, but `scale` is not used for reports -- each FIPS is reported as its own site). Provide exactly one of `sites`, `shape`, or `fips` per request, plus:
 - `sitenumber` - default `0` = aggregate **multisite report**; a positive integer reports on that one site.
-- `fileextension` - `pdf` (default) or `html`.
+- `fileextension` - `html` or `pdf`; default if omitted: `html` for the (default) multisite report, `pdf` when a single `sitenumber` is chosen.
 
 Each `fips` code is a separate site. `shape` is a GeoJSON FeatureCollection string (one or more polygons). Returns the rendered report (HTML or PDF), same as GET `/report`.
 

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -268,10 +268,10 @@ report_response <- function(result, method, to_map, sitenum, ext, res) {
 #* @param buffer The buffer radius in miles
 #* @param radius Synonym for buffer.
 #* @param sitenumber Which site to report on. Defaults to 1 (single-site). Use 0 (or "overall") for an aggregate MULTISITE report across all sites.
-#* @param fileextension Whether to return a PDF or HTML file. Defaults to PDF.
+#* @param fileextension "html" or "pdf". Default if omitted: pdf for a single-site report (better page breaks when printing), html for a multisite report (sitenumber=0/overall) -- html is much faster to generate and its interactive map links each site to its own report.
 #* @serializer contentType list(type = "application/octet-stream")
 #* @get /report
-function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius = NULL, sitenumber=1, fileextension="pdf", res) {
+function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius = NULL, sitenumber=1, fileextension = NULL, res) {
   if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # Determine the input method and prepare the area.
   method <- if (!is.null(lat) && !is.null(lon)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
@@ -310,6 +310,19 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
   sitenum <- if (tolower(as.character(sitenumber)) %in% c("0", "overall")) 0 else suppressWarnings(as.numeric(sitenumber))
   if (is.na(sitenum)) sitenum <- 1
 
+  # Default report format (when fileextension is not specified) mirrors the
+  # EJAM package's report links (Public-Environmental-Data-Partners/EJAM#443):
+  # - single-site report -> pdf: the traditional printable community report,
+  #   with proper page breaks for printing.
+  # - multisite report (sitenumber=0/overall) -> html: generated several times
+  #   faster (no headless-Chrome PDF steps), so the user gets the report much
+  #   sooner, and its interactive map lets the user click any site's point to
+  #   request that one site's report -- which a static PDF map cannot do.
+  # An explicitly passed fileextension always overrides this.
+  if (is.null(fileextension)) {
+    fileextension <- if (sitenum == 0) "html" else "pdf"
+  }
+
   # Perform the EJAM analysis.
   result <- tryCatch(
     ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), endpoint="report"),
@@ -341,10 +354,10 @@ function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius =
 #* @param buffer The buffer radius in miles (out from a polygon edge, or around a point)
 #* @param radius Synonym for buffer.
 #* @param sitenumber Which site to report on. Defaults to 0 = aggregate MULTISITE report across all sites.
-#* @param fileextension "pdf" (default) or "html"
+#* @param fileextension "html" or "pdf". Default if omitted: html for the (default) multisite report, pdf when a single sitenumber is chosen. See GET /report.
 #* @serializer contentType list(type = "application/octet-stream")
 #* @post /report
-function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sitenumber = 0, fileextension = "pdf", res) {
+function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sitenumber = 0, fileextension = NULL, res) {
   if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # One method per analysis; require exactly one input so an ambiguous request
   # (e.g. both sites and fips) fails cleanly instead of silently picking one.
@@ -357,6 +370,14 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
   # 0 or "overall" -> aggregate multisite report; otherwise the chosen single site.
   sitenum <- if (tolower(as.character(sitenumber)) %in% c("0", "overall")) 0 else suppressWarnings(as.numeric(sitenumber))
   if (is.na(sitenum)) sitenum <- 0
+
+  # Default format mirrors GET /report (and Public-Environmental-Data-Partners/EJAM#443):
+  # html for the multisite report (much faster to generate; interactive map
+  # links each site to its own report), pdf for a single-site report (better
+  # page breaks when printing). Explicit fileextension always overrides.
+  if (is.null(fileextension)) {
+    fileextension <- if (sitenum == 0) "html" else "pdf"
+  }
 
   result <- tryCatch(
     ejamit_interface(area = area, method = method, buffer = as.numeric(buffer), endpoint = "report"),


### PR DESCRIPTION
Mirrors the EJAM package's report-link defaults (Public-Environmental-Data-Partners/EJAM#443) for requests that don't specify `fileextension`, so users get reports as fast as possible in the format that suits each report type:

- **Multisite report (`sitenumber=0`/`overall`) → `html`.** HTML is generated several times faster than PDF (the PDF path adds two headless-Chrome steps with ~9 s of fixed waits), so the user sees the report much sooner. HTML is also simply better for a multisite report: its **interactive map lets the user click any site's point to request that one site's report** — a static PDF map can't do that.
- **Single-site report → `pdf`,** the traditional printable community report: **PDF has proper page breaks when printing**, which the single-site report is often used for.

An explicitly passed `fileextension` always overrides the default, so existing callers that pass it — including the EJAM app's links after Public-Environmental-Data-Partners/EJAM#443 — are unaffected. README and Swagger docs updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)