### PR TITLE
Fix zero-population single-site reports: let them render (EJAM#468), with a fail-safe instead of a broken 1-byte 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ point, area (polygon), or FIPS geography.
 
 `report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. If `fileextension` is omitted, a single-site report is returned as PDF and a multisite report as HTML; pass `fileextension` explicitly to override.
 
+A single-site report needs residents to report on: if the analysis finds population 0 within the requested distance of the chosen site (e.g. a small buffer around a point in an unpopulated area), the endpoint returns an error page explaining that, rather than a report. Use a larger `buffer`, or `sitenumber=0` for an overall multisite summary, instead.
+
 ### Examples
 A report on one county: https://api.ejanalysis.com/report?fips=10001
 
-A report on residents within a 1 mile radius (buffer) of one point in the Phoenix area: https://api.ejanalysis.com/report?lat=33&lon=-112&buffer=1
+A report on residents within a 1 mile radius (buffer) of one point in downtown Phoenix: https://api.ejanalysis.com/report?lat=33.45&lon=-112.07&buffer=1
 
 A multisite report over two points, 3 mile radius, as pdf: https://ejamapi-84652557241.us-central1.run.app/report?lat=33,34&lon=-112,-114&buffer=3&sitenumber=0&fileextension=pdf
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ point, area (polygon), or FIPS geography.
 
 `report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. If `fileextension` is omitted, a single-site report is returned as PDF and a multisite report as HTML; pass `fileextension` explicitly to override.
 
-A single-site report needs residents to report on: if the analysis finds population 0 within the requested distance of the chosen site (e.g. a small buffer around a point in an unpopulated area), the endpoint returns an error page explaining that, rather than a report. Use a larger `buffer`, or `sitenumber=0` for an overall multisite summary, instead.
+If the analysis finds population 0 within the requested distance of the chosen site (e.g. a small buffer around a point in an unpopulated area), a single-site report still renders, showing zero residents — supported by EJAM versions that include [Public-Environmental-Data-Partners/EJAM#468](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/468) (merged after v3.2022.1). On older EJAM versions that cannot render a zero-population report, the endpoint returns a clear error page rather than a broken download. Either way, a larger `buffer` — or `sitenumber=0` for an overall multisite summary — gives a report covering actual residents.
 
 ### Examples
 A report on one county: https://api.ejanalysis.com/report?fips=10001

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -240,8 +240,33 @@ report_response <- function(result, method, to_map, sitenum, ext, res, cache_hea
     res$body <- handle_error("fileextension must be 'html' or 'pdf'.", "html")
     return(res)
   }
+  # A single-site report on a site where the analysis found no residents (e.g.
+  # a small buffer in an unpopulated area: /report?lat=33&lon=-112&buffer=1)
+  # does not render -- ejam2report() returns a bare NA that plumber would ship
+  # as a 1-byte "application/pdf" 200, an unopenable download that the edge
+  # cache would then serve for a day. Catch it up front and return a clear
+  # error page instead (error responses are no-store, so never cached).
+  if (sitenum > 0 && is.data.frame(result$results_bysite) && sitenum <= nrow(result$results_bysite)) {
+    siterow <- result$results_bysite[sitenum, ]
+    pop_i <- suppressWarnings(as.numeric(siterow$pop[1]))
+    no_residents <- isFALSE(as.logical(siterow$valid[1])) || (!is.na(pop_i) && pop_i <= 0)
+    if (no_residents) {
+      return(html_error(res, 400, paste0(
+        "No residents were found for this site (population is 0 within the requested distance), ",
+        "so a single-site report cannot be generated. Try a larger buffer/radius, ",
+        "or use sitenumber=0 for an overall multisite summary.")))
+    }
+  }
+
   report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"),
     launch_browser = FALSE, site_method = method, shp = to_map, fileextension = ext)
+
+  # Belt-and-braces for any other path that yields no real report content
+  # (NULL, empty, or a bare logical NA): never ship an empty body as a 200.
+  if (is.null(report_output) || length(report_output) == 0 ||
+      (length(report_output) == 1 && is.logical(report_output))) {
+    return(html_error(res, 500, "Report generation returned no content for this request."))
+  }
 
   # Successful reports are deterministic for a given URL + deployed data
   # release, so GET responses are marked edge-cacheable (the Cloudflare proxy

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -240,32 +240,29 @@ report_response <- function(result, method, to_map, sitenum, ext, res, cache_hea
     res$body <- handle_error("fileextension must be 'html' or 'pdf'.", "html")
     return(res)
   }
-  # A single-site report on a site where the analysis found no residents (e.g.
-  # a small buffer in an unpopulated area: /report?lat=33&lon=-112&buffer=1)
-  # does not render -- ejam2report() returns a bare NA that plumber would ship
-  # as a 1-byte "application/pdf" 200, an unopenable download that the edge
-  # cache would then serve for a day. Catch it up front and return a clear
-  # error page instead (error responses are no-store, so never cached).
-  if (sitenum > 0 && is.data.frame(result$results_bysite) && sitenum <= nrow(result$results_bysite)) {
-    siterow <- result$results_bysite[sitenum, ]
-    pop_i <- suppressWarnings(as.numeric(siterow$pop[1]))
-    no_residents <- isFALSE(as.logical(siterow$valid[1])) || (!is.na(pop_i) && pop_i <= 0)
-    if (no_residents) {
-      return(html_error(res, 400, paste0(
-        "No residents were found for this site (population is 0 within the requested distance), ",
-        "so a single-site report cannot be generated. Try a larger buffer/radius, ",
-        "or use sitenumber=0 for an overall multisite summary.")))
-    }
-  }
-
+  # NOTE: no pre-render check here on purpose. A single-site report on a site
+  # where the analysis found no residents (e.g. a small buffer in an
+  # unpopulated area: /report?lat=33&lon=-112&buffer=1) is a legitimate
+  # request: EJAM versions that include
+  # Public-Environmental-Data-Partners/EJAM#468 (merged after v3.2022.1)
+  # render a real report for it, so the API must let ejam2report() handle it.
   report_output <- ejam2report(result, sitenumber = sitenum, return_html = (ext == "html"),
     launch_browser = FALSE, site_method = method, shp = to_map, fileextension = ext)
 
-  # Belt-and-braces for any other path that yields no real report content
-  # (NULL, empty, or a bare logical NA): never ship an empty body as a 200.
+  # Fail-safe: never ship a no-content result as a 200. When ejam2report()
+  # cannot render (it returns a bare logical NA -- e.g. the zero-population
+  # single-site case on EJAM versions without EJAM#468), plumber would
+  # otherwise serialize that as a 1-byte "application/pdf" 200, an unopenable
+  # download that the edge cache then serves for a day. Return a clear,
+  # uncacheable (no-store) error page instead.
   if (is.null(report_output) || length(report_output) == 0 ||
       (length(report_output) == 1 && is.logical(report_output))) {
-    return(html_error(res, 500, "Report generation returned no content for this request."))
+    return(html_error(res, 500, paste0(
+      "Report generation returned no content for this request. ",
+      "This can happen when the analysis finds no residents at the chosen site ",
+      "(population 0 within the requested distance) and the EJAM version deployed here ",
+      "cannot yet render a zero-population report. ",
+      "Try a larger buffer/radius, or sitenumber=0 for an overall multisite summary.")))
   }
 
   # Successful reports are deterministic for a given URL + deployed data


### PR DESCRIPTION
## Problem

A single-site `/report` request where the analysis finds **no residents** returns HTTP 200 with a **1-byte null body** labeled `application/pdf` (or `text/html`) — an unopenable download. Found in the 2026-07-11 production smoke test.

The README's own example #2 was this exact case: `?lat=33&lon=-112&buffer=1` — that point is in unpopulated desert SW of Phoenix, and a 1-mile buffer catches population 0 (`/data` confirms `pop=0, valid=FALSE`; `buffer=2`+ works).

Two aggravating factors:
- Successful-looking GET responses carry `Cache-Control: public, max-age=86400`, so **Cloudflare edge-caches the broken byte for a day** (verified `cf-cache-status: HIT` on the live URL).
- The per-site **"EJAM Report" links embedded in `/data` output are single-site links**, so any zero-population site produces this in the wild, not just hand-typed URLs.

Mechanism: `ejam2report()` returns a bare `NA` for the unrenderable single-site case, and plumber serializes that as one byte.

## Fix (reworked per review)

An earlier version of this branch blocked zero-population sites with a pre-render 400. Review ([this thread](https://github.com/Public-Environmental-Data-Partners/EJAM-API/pull/48#discussion_r3592616424)) correctly required the real report to render instead, and the package-side fix has since landed: **Public-Environmental-Data-Partners/EJAM#468** (merged to EJAM `development`, after `v3.2022.1`) makes `ejam2report()` render a real single-site report for a zero-population site. So this PR now:

- **Removes the pre-render zero-pop 400 entirely** — the API must not block the legitimate report path.
- **Keeps a single post-render fail-safe**: if `ejam2report()` yields no content (NULL / empty / bare logical `NA`), return a clear **500 error page** (`Cache-Control: no-store`, so never edge-cached) with guidance (larger buffer, or `sitenumber=0`), instead of ever shipping an empty body as a cacheable 200.
- README: `/report` docs describe the version-dependent behavior; example #2 uses a populated downtown-Phoenix point (`lat=33.45&lon=-112.07`, ~17,700 residents at 1 mile).

### Behavior by pinned EJAM version

| Deployed EJAM | `/report?lat=33&lon=-112&buffer=1` (zero-pop single-site) |
|---|---|
| `v3.2022.1` (current pin) | **500** clear error page, `no-store` — fail-safe catches the bare `NA` (today: broken cacheable 1-byte 200) |
| Any release including Public-Environmental-Data-Partners/EJAM#468 | **200 real report** showing zero residents — no API change needed; this PR is what un-blocks that path |

## Verified locally (plumber + EJAM v3.2022.1, the current pin)

| Request | Before (main) | After |
|---|---|---|
| `/report?lat=33&lon=-112&buffer=1` | 200, 1 byte, cacheable | **500** text/html 376-byte error page, `no-store`, explanatory message |
| `/report?lat=33.45&lon=-112.07&buffer=1&fileextension=html` | 200 | 200, 2.8 MB report, cacheable (pass-through untouched) |
| `/report?lat=33&lon=-112&buffer=1&sitenumber=0` (multisite) | 200, works | 200, 2.7 MB summary (guard never fires on real content) |

The fail-safe fires only on NULL/empty/bare-logical output, so it cannot intercept a rendered report — the EJAM#468 path flows through the same pass-through verified in row 2.

## Deploy notes

- **Cloudflare purge still needed**: the broken 1-byte response is cached at the edge for the old README-example URL. After deploy, purge `api.ejanalysis.com/report?lat=33&lon=-112&buffer=1` (and any other known zero-pop report URLs) — or wait out the 24 h TTL.
- **When the EJAM pin advances** past `v3.2022.1` to a release containing Public-Environmental-Data-Partners/EJAM#468, zero-population single-site reports start rendering automatically; nothing further to change in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
