### PR TITLE
Default radius/buffer to 0 for FIPS and shape inputs (GET /report + POST /handoff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ point, area (polygon), or FIPS geography.
 - `lon` - the longitude
 - `fips` - A FIPS code for a specific US Census geography, like fips=10 for one state, or comma-separated list like fips=10001,10003,10005 for 3 counties
 - `shape` - a GeoJSON text-encoded object describing an area of interest, such as a polygon of neighborhood boundaries
-- `buffer` (or `radius`, a synonym) - radius, in miles, around a point or out from the edge of a polygon to extend the search. EJAM default = 3. *Note: adding buffers around fips units may not be implemented yet.
+- `buffer` (or `radius`, a synonym) - radius, in miles, around a point or out from the edge of a polygon to extend the search. Default if omitted: 3 for `lat`/`lon` points; 0 for `fips` or `shape` (analyze inside the boundary itself, no buffer). *Note: adding buffers around fips units may not be implemented yet.
 - `sitenumber` - which site to report on when more than one is supplied. Default = 1 (a single-site report on the first site). Use `sitenumber=0` (or `sitenumber=overall`) to get an aggregate **multisite report** that summarizes all of the supplied sites together. Each comma-separated `fips` code is treated as a separate site (no expansion), so `fips=10001,10003&sitenumber=0` reports on those two counties together. When only **one** site is supplied (as in the per-site report links EJAM builds from multisite results), `sitenumber=N` with N > 1 labels the report header "Site N" -- that site's row in the original analysis -- instead of "Site 1". (The "Site N" label requires the deployed `EJAM_VERSION` to include `ejam2report(sitenumber_label=)` from Public-Environmental-Data-Partners/EJAM#470; with an older pinned EJAM the report falls back to the default "Site 1" header.)
 - `fileextension` - `html` or `pdf`. Default if omitted: `pdf` for a single-site report (better page breaks when printing), `html` for a multisite report (`sitenumber=0`/`overall`) -- HTML is generated much faster, and its interactive map lets you click any site's point to open that site's own report.
 
-`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles but can be explicitly set to 0. If `fileextension` is omitted, a single-site report is returned as PDF and a multisite report as HTML; pass `fileextension` explicitly to override.
+`report` expects either `lat`/`lon` OR `shape` OR `fips`. The default buffer around a point is 3 miles; for `fips` or `shape` the default buffer is 0 (the boundary itself). Either can be set explicitly. If `fileextension` is omitted, a single-site report is returned as PDF and a multisite report as HTML; pass `fileextension` explicitly to override.
 
 If the analysis finds population 0 within the requested distance of the chosen site (e.g. a small buffer around a point in an unpopulated area), a single-site report still renders, showing zero residents — supported by EJAM versions that include [Public-Environmental-Data-Partners/EJAM#468](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/468) (merged after v3.2022.1). On older EJAM versions that cannot render a zero-population report, the endpoint returns a clear error page rather than a broken download. Either way, a larger `buffer` — or `sitenumber=0` for an overall multisite summary — gives a report covering actual residents.
 
@@ -108,7 +108,7 @@ df
 
 Two endpoints let an external app (e.g. EJScreen) hand a set of selected places to the full EJAM app without hitting URL-length limits (important for polygons):
 
-- `POST /handoff` — body may contain `sites` (array of `{lat,lon}`), `fips` (array of codes), `shape` (a GeoJSON `FeatureCollection`), and `radius`. Returns `{"token": "...", "expires": <epoch seconds>}`.
+- `POST /handoff` — body may contain `sites` (array of `{lat,lon}`), `fips` (array of codes), `shape` (a GeoJSON `FeatureCollection`), and `radius` (default if omitted: 0 for `fips`/`shape` handoffs, i.e. analyze inside the boundary itself; none for `sites` — the EJAM app applies its own point default). Returns `{"token": "...", "expires": <epoch seconds>}`.
 - `GET /handoff/<token>` — returns the stored payload as JSON.
 
 The caller opens the EJAM app at `https://ejam.publicenvirodata.org/?handoff=<token>`; the app fetches `GET /handoff/<token>` on startup and pre-loads those places.

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -338,16 +338,22 @@ report_response <- function(result, method, to_map, sitenum, ext, res, cache_hea
 #* @param lon Longitude of the site
 #* @param shape A GeoJSON string representing the area of interest
 #* @param fips A FIPS code for a specific US Census geography
-#* @param buffer The buffer radius in miles
+#* @param buffer The buffer radius in miles. Default if omitted: 3 for lat/lon points; 0 for fips or shape (analyze inside the boundary itself, no buffer).
 #* @param radius Synonym for buffer.
 #* @param sitenumber Which site to report on. Defaults to 1 (single-site). Use 0 (or "overall") for an aggregate MULTISITE report across all sites. When only ONE site is submitted (as in the per-site report links EJAM builds from multisite results), N > 1 is used to label the report header "Site N" -- that site's row in the original analysis -- instead of "Site 1". (The "Site N" label requires an EJAM release whose ejam2report() has the sitenumber_label parameter -- EJAM#470; with an older pinned EJAM the report falls back to the default "Site 1" header.)
 #* @param fileextension "html" or "pdf". Default if omitted: pdf for a single-site report (better page breaks when printing), html for a multisite report (sitenumber=0/overall) -- html is much faster to generate and its interactive map links each site to its own report.
 #* @serializer contentType list(type = "application/octet-stream")
 #* @get /report
-function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = 3, radius = NULL, sitenumber=1, fileextension = NULL, res) {
+function(lat = NULL, lon = NULL, shape = NULL, fips = NULL, buffer = NULL, radius = NULL, sitenumber=1, fileextension = NULL, res) {
   if (!is.null(radius)) {buffer <- radius}  # radius is a synonym (alias) for buffer
   # Determine the input method and prepare the area.
   method <- if (!is.null(lat) && !is.null(lon)) "latlon" else if (!is.null(shape)) "SHP" else if (!is.null(fips)) "FIPS" else NULL
+
+  # Buffer default depends on the method: points keep the traditional 3-mile
+  # ring (a bare point is not an area, so some buffer is required), while FIPS
+  # and polygon inputs are already areas -- their natural default is 0, meaning
+  # analyze inside the boundary itself with no buffer.
+  if (is.null(buffer)) {buffer <- if (identical(method, "latlon")) 3 else 0}
 
   # Multisite support: lat/lon and fips may be comma-separated lists, one site
   # each. Splitting here lets the same endpoint serve single-site (one value)
@@ -527,7 +533,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 #* @param sites Array of {lat, lon} site objects
 #* @param fips Array of FIPS codes (each one a separate site)
 #* @param shape A GeoJSON FeatureCollection of polygons
-#* @param radius Buffer radius in miles
+#* @param radius Buffer radius in miles. Default if omitted: 0 for FIPS or SHP handoffs (analyze inside the boundary itself, no buffer); no default for latlon (the EJAM app applies its own point default).
 #* @param buffer Synonym for radius.
 #* @post /handoff
 function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, buffer = NULL, res) {
@@ -540,6 +546,15 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   if (is.null(method)) {
     method <- if (!is.null(sites)) "latlon" else if (!is.null(shape)) "SHP" else "FIPS"
   }
+  # FIPS and polygon inputs are already areas, so their natural buffer default
+  # is 0 (analyze inside the boundary itself). Store the explicit 0 rather than
+  # leaving radius NULL: an absent field serializes as JSON {} in the GET
+  # /handoff/<token> payload, which clients can misparse (a zero-length list,
+  # not NULL, in R -- it crashed the EJAM app's launch handler; see
+  # Public-Environmental-Data-Partners/EJAM#465). Points get no default here:
+  # a bare point needs SOME positive buffer, and the EJAM app applies its own
+  # point-method default/minimum at the radius slider.
+  if (is.null(radius) && method %in% c("FIPS", "SHP")) {radius <- 0}
   if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
     res$status <- 429
     return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens). Retry after a short delay; tokens expire after 1 hour.", as.integer(.handoff_max_tokens))))

--- a/rest_controller.r
+++ b/rest_controller.r
@@ -533,7 +533,7 @@ function(sites = NULL, shape = NULL, fips = NULL, buffer = 0, radius = NULL, sit
 #* @param sites Array of {lat, lon} site objects
 #* @param fips Array of FIPS codes (each one a separate site)
 #* @param shape A GeoJSON FeatureCollection of polygons
-#* @param radius Buffer radius in miles. Default if omitted: 0 for FIPS or SHP handoffs (analyze inside the boundary itself, no buffer); no default for latlon (the EJAM app applies its own point default).
+#* @param radius Buffer radius in miles. Default if omitted: 0 when the payload has fips or shape and no sites (analyze inside the boundary itself, no buffer); no default when sites are present (the EJAM app applies its own point default).
 #* @param buffer Synonym for radius.
 #* @post /handoff
 function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, buffer = NULL, res) {
@@ -551,10 +551,15 @@ function(method = NULL, sites = NULL, fips = NULL, shape = NULL, radius = NULL, 
   # leaving radius NULL: an absent field serializes as JSON {} in the GET
   # /handoff/<token> payload, which clients can misparse (a zero-length list,
   # not NULL, in R -- it crashed the EJAM app's launch handler; see
-  # Public-Environmental-Data-Partners/EJAM#465). Points get no default here:
-  # a bare point needs SOME positive buffer, and the EJAM app applies its own
-  # point-method default/minimum at the radius slider.
-  if (is.null(radius) && method %in% c("FIPS", "SHP")) {radius <- 0}
+  # Public-Environmental-Data-Partners/EJAM#465). Keyed on the payload CONTENT
+  # (fips/shape present, sites absent), not the method string: method is
+  # caller-provided and unvalidated, so e.g. {method:"latlon", fips:[...]} or a
+  # lowercase "fips" would dodge a method-based default -- and the EJAM app
+  # likewise dispatches on payload content, ignoring method. When sites are
+  # present they take precedence in the app (points), which applies its own
+  # point-method default/minimum at the radius slider, so no default is stored:
+  # a bare point needs SOME positive buffer, not 0.
+  if (is.null(radius) && is.null(sites) && (!is.null(fips) || !is.null(shape))) {radius <- 0}
   if (is.finite(.handoff_max_tokens) && length(ls(.handoff_store)) >= .handoff_max_tokens) {
     res$status <- 429
     return(handle_error(sprintf("Handoff token capacity reached (max %d active tokens). Retry after a short delay; tokens expire after 1 hour.", as.integer(.handoff_max_tokens))))


### PR DESCRIPTION
## What & why

Companion to Public-Environmental-Data-Partners/EJAM#465 / Public-Environmental-Data-Partners/EJAM#466 (EJAM app crash on EJScreen "Send to EJAM" token handoffs).

Areas defined by FIPS codes or polygons are **already areas**, so their natural buffer default is **0** — analyze inside the boundary itself. Points keep the traditional **3-mile** default (a bare point is not an area, so some buffer is required).

## Changes

- **`GET /report`**: `buffer` default is now method-dependent — **3 for lat/lon points, 0 for `fips` or `shape`** — instead of a flat 3. Previously, omitting `buffer` on e.g. `?fips=10001` silently analyzed a 3-mile ring around the county. Explicit `buffer`/`radius` values are honored as before. (`POST /report` already defaulted to 0 and is unchanged.)
- **`POST /handoff`**: when `radius` is omitted for a **FIPS or SHP** handoff, store an **explicit `radius = 0`** rather than leaving it NULL. An absent field serializes as JSON `{}` in the `GET /handoff/<token>` payload, which R clients can misparse (`jsonlite::fromJSON()` gives a zero-length list, not NULL) — that's what crashed the EJAM app for every county/tract/polygon handoff (Public-Environmental-Data-Partners/EJAM#465). `latlon` handoffs get no default here: the EJAM app applies its own point-method default/minimum at the radius slider.
- **README + OpenAPI param docs** updated to match.

## Testing (live local plumber instance)

Handoff round-trips (`POST /handoff` → `GET /handoff/<token>`):

| payload | radius returned |
|---|---|
| `{"fips":["10001","10003"]}` | `[0]` (was `{}`) |
| `{"shape":<FeatureCollection>}` | `[0]` (was `{}`) |
| `{"sites":[{"lat":39,"lon":-75.5}]}` | `{}` (unchanged — no default for points) |
| `{"sites":[...],"radius":7}` | `[7]` (pass-through) |
| `{"fips":["10001"],"buffer":2}` | `[2]` (buffer alias pass-through) |

Reports (full local analysis runs, HTTP 200):
- `GET /report?fips=10001&fileextension=html` → report generated with `buffer=0&sitetype=fips` in its site links (no more implicit 3-mile ring around the county).
- `GET /report?lat=39&lon=-75.5&fileextension=html` → still "within 3 mile" / `buffer=3`.

## Related PRs

- Public-Environmental-Data-Partners/EJAM#466 — app-side fix: tolerate `{}` payload fields (defense-in-depth; the app should not crash on any payload shape).
- Public-Environmental-Data-Partners/EJScreen#73 — `multisite.js` sends an explicit `radius: 0` for fips/polygon handoffs, so the deployed EJScreen doesn't depend on this API redeploy either.

Any ONE of the three merged+deployed unbreaks the "Send to EJAM" flow; all three together make each layer explicit and robust. Not merging myself — flagging for review per PEDP ownership.