### PR TITLE
Harden OpenAPI description handling

### DIFF
--- a/main.r
+++ b/main.r
@@ -11,7 +11,7 @@ r <- plumber::pr_set_api_spec(r, function(spec) {
   ejam_ref <- Sys.getenv("EJAM_VERSION")
   if (nzchar(ejam_ref)) {
     description <- spec$info$description
-    if (is.null(description) || !length(description) || is.na(description)) {
+    if (is.null(description) || length(description) != 1L || is.na(description)) {
       description <- ""
     }
     separator <- if (nzchar(description)) "\n\n" else ""


### PR DESCRIPTION
## Summary

- make the OpenAPI description guard explicitly scalar-safe
- treat missing, empty, `NA`, and non-scalar descriptions as empty before appending the `EJAM_VERSION` build-ref provenance
- keep the launcher behavior synchronized with the paired EJAM follow-up

## Why

A late Copilot review on [EJAM#579](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/579#discussion_r3864738632) identified a latent case: if a non-scalar `spec$info$description` reaches this callback, `is.na(description)` returns more than one logical value and the `if` condition errors. Plumber normally supplies a scalar description, so this is defensive hardening rather than a known production failure. The one-line change checks for exactly one value before calling `is.na()`.

This follows [EJAM-API#55](https://github.com/Public-Environmental-Data-Partners/EJAM-API/pull/55) and references [EJAM-API#54](https://github.com/Public-Environmental-Data-Partners/EJAM-API/issues/54). The corresponding EJAM launcher change is in paired draft [EJAM#591](https://github.com/Public-Environmental-Data-Partners/EJAM/pull/591).

## Validation

- `main.r` parsed successfully
- the EJAM and EJAM-API callback bodies were identical after the paired edit
- callback tests passed with `EJAM_VERSION` unset, empty, and set to `v3.2022.2`
- description tests passed for `NULL`, `character()`, `NA_character_`, a length-two character vector, and a normal scalar description
- existing query-pagination tests passed: 33 assertions
- `git diff --check` passed
- staged content contained no local paths or personal identifiers

This is a draft for maintainer review. It does not merge, rebuild, or deploy EJAM-API.

— ChatGPT
